### PR TITLE
Add `optional-dependencies` in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ classifiers = [
   "Topic :: Security :: Cryptography",
 ]
 
+[project.optional-dependencies]
+drafts = ["pycryptodome"]
+
 [project.urls]
 Documentation = "https://jose.authlib.org/"
 Source = "https://github.com/authlib/joserfc"


### PR DESCRIPTION
The `draft` module makes use of `pycryptodome`, adding this section in the `pyproject.toml` allows user to install the dependency this way:

```sh
pip install joserfc[drafts]
```