### PR TITLE
fix(registry): support not-empty validation

### DIFF
--- a/src/joserfc/rfc7519/registry.py
+++ b/src/joserfc/rfc7519/registry.py
@@ -25,6 +25,10 @@ class ClaimsRegistry:
     def check_value(self, claim_name: str, value: Any) -> None:
         option = self.options.get(claim_name)
         if option:
+            option_not_empty = option.get("not_empty")
+            if option_not_empty and not value:
+                raise InvalidClaimError(claim_name)
+
             option_value = option.get("value")
             if option_value and value != option_value:
                 raise InvalidClaimError(claim_name)

--- a/tests/jwt/test_claims.py
+++ b/tests/jwt/test_claims.py
@@ -46,6 +46,12 @@ class TestJWTClaims(TestCase):
 
         claims_requests.validate({"sub": "a", "iss": "a", "name": "joserfc"})
 
+    def test_essential_empty_value(self):
+        claims_requests = jwt.JWTClaimsRegistry(sub={"essential": True, "not_empty": True})
+        self.assertRaises(InvalidClaimError, claims_requests.validate, {"sub": ""})
+
+        claims_requests.validate({"sub": "a"})
+
     def test_option_value(self):
         claims_requests = jwt.JWTClaimsRegistry(sub={"essential": True, "value": "123"})
         self.assertRaises(InvalidClaimError, claims_requests.validate, {"sub": "a"})


### PR DESCRIPTION
authlib fails if essential claim is empty, new implementation may choose to accept empty strings.

in most cases empty value should not be accepted, it is handy to be able to these.

raise InvalidClaimError when not_empty=True claim option:

```python
    def test_essential_empty_value(self):
        claims_requests = jwt.JWTClaimsRegistry(sub={"essential": True, "not_empty": True})
        self.assertRaises(InvalidClaimError, claims_requests.validate, {"sub": ""})
```