### PR TITLE
fix(registry): support List[str] and List[int] values

### DIFF
--- a/src/joserfc/rfc7519/registry.py
+++ b/src/joserfc/rfc7519/registry.py
@@ -12,7 +12,7 @@ from ..errors import (
 class ClaimsOption(TypedDict, total=False):
     essential: bool
     value: Union[str, int]
-    values: List[Union[str, int]]
+    values: Union[List[Union[str, int]], List[str], List[int]]
 
 
 class ClaimsRegistry:


### PR DESCRIPTION
resolves:

```
    error: Incompatible types (expression has type "list[str]", TypedDict
    item "values" has type "list[str | int]")  [typeddict-item]
```