### PR TITLE
fix(registry): treat null claim value as missing

### DIFF
--- a/src/joserfc/rfc7519/registry.py
+++ b/src/joserfc/rfc7519/registry.py
@@ -39,9 +39,9 @@ class ClaimsRegistry:
                 raise InvalidClaimError(claim_name)
 
     def validate(self, claims: Dict[str, Any]) -> None:
-        missed_key = self.essential_keys - set(claims.keys())
-        if missed_key:
-            raise MissingClaimError(",".join(missed_key))
+        missed_keys = {key for key in self.essential_keys if claims.get(key) is None}
+        if missed_keys:
+            raise MissingClaimError(",".join(sorted(missed_keys)))
 
         for key in claims:
             value = claims[key]

--- a/tests/jwt/test_claims.py
+++ b/tests/jwt/test_claims.py
@@ -48,8 +48,10 @@ class TestJWTClaims(TestCase):
 
     def test_essential_empty_value(self):
         claims_requests = jwt.JWTClaimsRegistry(sub={"essential": True})
+        self.assertRaises(MissingClaimError, claims_requests.validate, {"sub": None})
         self.assertRaises(InvalidClaimError, claims_requests.validate, {"sub": ""})
         claims_requests = jwt.JWTClaimsRegistry(sub={"essential": True, "allow_blank": True})
+        self.assertRaises(MissingClaimError, claims_requests.validate, {"sub": None})
         claims_requests.validate({"sub": ""})
 
     def test_option_value(self):


### PR DESCRIPTION
Assert the following to be true:

|essential   |allow_blank    |value       |result
|-----------|----------------|-----------|-----------------
|True        |False           |missing     |MissingClaimError
|True        |False           |null        |MissingClaimError
|True        |False           |""          |InvalidClaimError
|True        |False           |"x"         |Accepted
|True        |True            |missing     |MissingClaimError
|True        |True            |null        |MissingClaimError
|True        |True            |""          |Accepted
|True        |True            |"x"         |Accepted

Code:

```python
    def test_essential_empty_value(self):
        claims_requests = jwt.JWTClaimsRegistry(sub={"essential": True})
        self.assertRaises(MissingClaimError, claims_requests.validate, {"sub": None})
```

---

@lepture : please tell me if you want to treat this as MissingClaimError or InvalidClaimError, I believe that JSON null value should be treated as missing.
