### PR TITLE
Throw an error on invalid base64 strings

### DIFF
--- a/src/joserfc/util.py
+++ b/src/joserfc/util.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Any
 import base64
 import struct
+import binascii
 import json
 
 
@@ -26,8 +27,10 @@ def json_dumps(data: Any, ensure_ascii: bool = False) -> str:
 
 
 def urlsafe_b64decode(s: bytes) -> bytes:
+    if b"+" in s or b"/" in s:
+        raise binascii.Error
     s += b"=" * (-len(s) % 4)
-    return base64.urlsafe_b64decode(s)
+    return base64.b64decode(s, b"-_", validate=True)
 
 
 def urlsafe_b64encode(s: bytes) -> bytes:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from joserfc import util
-
+import binascii
 
 class TestUtil(TestCase):
     def test_to_bytes(self):
@@ -22,3 +22,11 @@ class TestUtil(TestCase):
 
     def test_json_b64encode(self):
         self.assertEqual(util.json_b64encode("{}"), b"e30")
+
+    def test_urlsafe_b64decode(self):
+        self.assertEqual(util.urlsafe_b64decode(b'_foo123-'), b'\xfd\xfa(\xd7m\xfe')
+        self.assertRaises(
+            binascii.Error,
+            util.urlsafe_b64decode,
+            b'+foo123/'
+        )


### PR DESCRIPTION
RFC 4648 states that "implementations MUST reject the encoded data if it contains characters outside the base alphabet when interpreting base-encoded data, unless the specification referring to this document explicitly states otherwise."

RFC 7515 specifies base64url encoding as "base64 encoding using the URL- and filename-safe character set defined in Section 5 of RFC 4648, with all trailing '=' characters omitted and without the inclusion of any line breaks, whitespace, or _other additional characters_."

Python's `base64.urlsafe_b64decode()` does not validate its argument, ignoring unknown characters instead. [It also accepts "+" and "/" in addition to "-" and "_"](https://github.com/python/cpython/issues/125346).

`base64.b64decode()`'s validate argument makes it validate its input, but [it still accepts non-urlsafe base64 encoding as well](https://github.com/python/cpython/issues/125346).

This commit therefore changes `util.urlsafe_b64decode()` to explicitly check for "+" and "/" in input before passing it to `base64.b64decode()` with its validate argument set to `True`.