### PR TITLE
Adds __eq__ for comparing KeySet instances

### DIFF
--- a/src/joserfc/_keys.py
+++ b/src/joserfc/_keys.py
@@ -120,6 +120,11 @@ class KeySet:
     def __bool__(self) -> bool:
         return bool(self.keys)
 
+    def __eq__(self, other) -> bool:
+        if otherdict := getattr(other, 'as_dict', None):
+            return otherdict() == self.as_dict()
+        return False
+
     def as_dict(self, private: bool | None = None, **params: t.Any) -> KeySetSerialization:
         keys: list[DictKey] = []
 


### PR DESCRIPTION
Closes #36 

Adds an `__eq__` magic method for comparing KeySet instances