### PR TITLE
respect RFC6749 character set in error descriptions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ Unreleased
 - Use ``ECKey.binding.register_curve`` to register new supported curves.
 - Use ``UnsupportedAlgorithmError`` instead of ``ValueError`` in JWS/JWE registry.
 - Use ``MissingKeyTypeError`` and ``InvalidKeyIdError`` for errors in JWK.
+- Respect RFC6749 character set in error descriptions.
 
 1.0.4
 -----

--- a/src/joserfc/_keys.py
+++ b/src/joserfc/_keys.py
@@ -66,7 +66,7 @@ class JWKRegistry:
                 raise MissingKeyTypeError("Missing key type")
 
         if key_type not in cls.key_types:
-            raise InvalidKeyTypeError(f'Invalid key type: "{key_type}"')
+            raise InvalidKeyTypeError(f"Invalid key type: '{key_type}'")
 
         if isinstance(data, str):
             data = to_bytes(data)
@@ -93,7 +93,7 @@ class JWKRegistry:
             JWKRegistry.generate_key("EC", "P-256")
         """
         if key_type not in cls.key_types:
-            raise InvalidKeyTypeError(f'Invalid key type: "{key_type}"')
+            raise InvalidKeyTypeError(f"Invalid key type: '{key_type}'")
 
         key_cls = cls.key_types[key_type]
         return key_cls.generate_key(crv_or_size, parameters, private, auto_kid)  # type: ignore[arg-type]
@@ -143,7 +143,7 @@ class KeySet:
         for key in self.keys:
             if key.kid == kid:
                 return key
-        raise InvalidKeyIdError(f'No key for kid: "{kid}"')
+        raise InvalidKeyIdError(f"No key for kid: '{kid}'")
 
     def pick_random_key(self, algorithm: str) -> t.Optional[Key]:
         key_types = self.algorithm_keys.get(algorithm)

--- a/src/joserfc/errors.py
+++ b/src/joserfc/errors.py
@@ -61,7 +61,7 @@ class InvalidEncryptedKeyError(JoseError):
 
 class MissingAlgorithmError(JoseError):
     error = "missing_algorithm"
-    description = 'Missing "alg" value in header'
+    description = "Missing 'alg' value in header"
 
 
 class ConflictAlgorithmError(JoseError):
@@ -74,7 +74,7 @@ class UnsupportedAlgorithmError(JoseError):
 
 class MissingEncryptionError(JoseError):
     error = "missing_encryption"
-    description = 'Missing "enc" value in header'
+    description = "Missing 'enc' value in header"
 
 
 class BadSignatureError(JoseError):
@@ -99,14 +99,14 @@ class InvalidEncryptionAlgorithmError(JoseError):
 
 class InvalidCEKLengthError(JoseError):
     error = "invalid_cek_length"
-    description = 'Invalid "cek" length'
+    description = "Invalid 'cek' length"
 
 
 class InvalidClaimError(JoseError):
     error = "invalid_claim"
 
     def __init__(self, claim: str):
-        description = f'Invalid claim: "{claim}"'
+        description = f"Invalid claim: '{claim}'"
         super(InvalidClaimError, self).__init__(description=description)
 
 
@@ -114,7 +114,7 @@ class MissingClaimError(JoseError):
     error = "missing_claim"
 
     def __init__(self, claim: str):
-        description = f'Missing claim: "{claim}"'
+        description = f"Missing claim: '{claim}'"
         super(MissingClaimError, self).__init__(description=description)
 
 
@@ -122,7 +122,7 @@ class InsecureClaimError(JoseError):
     error = "insecure_claim"
 
     def __init__(self, claim: str):
-        description = f'Insecure claim "{claim}"'
+        description = f"Insecure claim '{claim}'"
         super(InsecureClaimError, self).__init__(description=description)
 
 

--- a/src/joserfc/registry.py
+++ b/src/joserfc/registry.py
@@ -184,12 +184,12 @@ def validate_registry_header(
         check_required: bool = True) -> None:
     for key, reg in registry.items():
         if check_required and reg.required and key not in header:
-            raise ValueError(f'Required "{key}" is missing in header')
+            raise ValueError(f"Required '{key}' is missing in header")
         if key in header:
             try:
                 reg.validate(header[key])
             except ValueError as error:
-                raise ValueError(f'"{key}" in header {error}')
+                raise ValueError(f"'{key}' in header {error}")
 
 
 def check_crit_header(header: Header) -> None:
@@ -197,4 +197,4 @@ def check_crit_header(header: Header) -> None:
     if "crit" in header:
         for k in header["crit"]:
             if k not in header:
-                raise ValueError(f'"{k}" is a critical header')
+                raise ValueError(f"'{k}' is a critical header")

--- a/src/joserfc/rfc7515/model.py
+++ b/src/joserfc/rfc7515/model.py
@@ -97,7 +97,7 @@ class JWSAlgModel(object, metaclass=ABCMeta):
 
     def check_key_type(self, key: Any) -> None:
         if key.key_type != self.key_type:
-            raise InvalidKeyTypeError(f'Algorithm "{self.name}" requires "{self.key_type}" key')
+            raise InvalidKeyTypeError(f"Algorithm '{self.name}' requires '{self.key_type}' key")
 
     @abstractmethod
     def sign(self, msg: bytes, key: Any) -> bytes:

--- a/src/joserfc/rfc7515/registry.py
+++ b/src/joserfc/rfc7515/registry.py
@@ -50,14 +50,14 @@ class JWSRegistry:
         :param name: value of the ``alg``, e.g. ``HS256``, ``RS256``
         """
         if name not in self.algorithms:
-            raise UnsupportedAlgorithmError(f'Algorithm of "{name}" is not supported')
+            raise UnsupportedAlgorithmError(f"Algorithm of '{name}' is not supported")
 
         if self.allowed:
             if name not in self.allowed:
-                raise UnsupportedAlgorithmError(f'Algorithm of "{name}" is not allowed')
+                raise UnsupportedAlgorithmError(f"Algorithm of '{name}' is not allowed")
         else:
             if name not in self.recommended:
-                raise UnsupportedAlgorithmError(f'Algorithm of "{name}" is not recommended')
+                raise UnsupportedAlgorithmError(f"Algorithm of '{name}' is not recommended")
         return self.algorithms[name]
 
     def check_header(self, header: Header) -> None:

--- a/src/joserfc/rfc7516/message.py
+++ b/src/joserfc/rfc7516/message.py
@@ -111,7 +111,7 @@ def _perform_decrypt(obj: EncryptionData, registry: JWERegistry) -> None:
         raise DecodeError('Invalid recipients')
 
     if len(cek_set) > 1:  # pragma: no cover
-        raise DecodeError('Multiple "cek" found')
+        raise DecodeError("Multiple 'cek' found")
 
     cek = cek_set.pop()
     if len(cek) * 8 != enc.cek_size:  # pragma: no cover

--- a/src/joserfc/rfc7516/models.py
+++ b/src/joserfc/rfc7516/models.py
@@ -175,7 +175,7 @@ class JWEEncModel(object, metaclass=ABCMeta):
 
     def check_iv(self, iv: bytes) -> bytes:
         if len(iv) * 8 != self.iv_size:  # pragma: no cover
-            raise ValueError('Invalid "iv" size')
+            raise ValueError("Invalid 'iv' size")
         return iv
 
     @abstractmethod

--- a/src/joserfc/rfc7516/registry.py
+++ b/src/joserfc/rfc7516/registry.py
@@ -102,14 +102,14 @@ class JWERegistry:
 
     def _check_algorithm(self, name: str, registry: dict[str, t.Any]) -> None:
         if name not in registry:
-            raise UnsupportedAlgorithmError(f'Algorithm of "{name}" is not supported')
+            raise UnsupportedAlgorithmError(f"Algorithm of '{name}' is not supported")
 
         if self.allowed:
             if name not in self.allowed:
-                raise UnsupportedAlgorithmError(f'Algorithm of "{name}" is not allowed')
+                raise UnsupportedAlgorithmError(f"Algorithm of '{name}' is not allowed")
         else:
             if name not in self.recommended:
-                raise UnsupportedAlgorithmError(f'Algorithm of "{name}" is not recommended')
+                raise UnsupportedAlgorithmError(f"Algorithm of '{name}' is not recommended")
 
 
 default_registry = JWERegistry()

--- a/src/joserfc/rfc7517/models.py
+++ b/src/joserfc/rfc7517/models.py
@@ -56,13 +56,13 @@ class NativeKeyBinding(metaclass=ABCMeta):
     def validate_dict_key_registry(cls, dict_key: DictKey, registry: KeyParameterRegistryDict) -> None:
         for k in registry:
             if registry[k].required and k not in dict_key:
-                raise ValueError(f'"{k}" is required')
+                raise ValueError(f"'{k}' is required")
 
             if k in dict_key:
                 try:
                     registry[k].validate(dict_key[k])
                 except ValueError as error:
-                    raise ValueError(f'"{k}" {error}')
+                    raise ValueError(f"'{k}' {error}")
 
     @classmethod
     def validate_dict_key_use_operations(cls, dict_key: DictKey) -> None:
@@ -71,7 +71,7 @@ class NativeKeyBinding(metaclass=ABCMeta):
             operations = cls.use_key_ops_registry[_use]
             for op in dict_key["key_ops"]:
                 if op not in operations:
-                    raise ValueError('"use" and "key_ops" does not match')
+                    raise ValueError("'use' and 'key_ops' does not match")
 
 
 class BaseKey(t.Generic[NativePrivateKey, NativePublicKey], metaclass=ABCMeta):
@@ -200,7 +200,7 @@ class BaseKey(t.Generic[NativePrivateKey, NativePublicKey], metaclass=ABCMeta):
         """
         designed_use = self.get("use")
         if designed_use and designed_use != use:
-            raise UnsupportedKeyUseError(f'This key is designed to be used for "{designed_use}"')
+            raise UnsupportedKeyUseError(f"This key is designed to be used for '{designed_use}'")
 
     def check_alg(self, alg: str) -> None:
         """Check if this key supports the given "alg".
@@ -210,7 +210,7 @@ class BaseKey(t.Generic[NativePrivateKey, NativePublicKey], metaclass=ABCMeta):
         """
         designed_alg = self.get("alg")
         if designed_alg and designed_alg != alg:
-            raise UnsupportedKeyAlgorithmError(f'This key is designed for algorithm "{designed_alg}"')
+            raise UnsupportedKeyAlgorithmError(f"This key is designed for algorithm '{designed_alg}'")
 
     def check_key_op(self, operation: str) -> None:
         """Check if the given key_op is supported by this key.
@@ -220,12 +220,12 @@ class BaseKey(t.Generic[NativePrivateKey, NativePublicKey], metaclass=ABCMeta):
         """
         key_ops = self.get("key_ops")
         if key_ops is not None and operation not in key_ops:
-            raise UnsupportedKeyOperationError(f'Unsupported key_op "{operation}"')
+            raise UnsupportedKeyOperationError(f"Unsupported key_op '{operation}'")
 
         assert operation in self.operation_registry
         reg = self.operation_registry[operation]
         if reg.private and not self.is_private:
-            raise UnsupportedKeyOperationError(f'Invalid key_op "{operation}" for public key')
+            raise UnsupportedKeyOperationError(f"Invalid key_op '{operation}' for public key")
 
     @t.overload
     def get_op_key(self, operation: t.Literal["verify", "encrypt", "wrapKey", "deriveKey"]) -> NativePublicKey: ...

--- a/src/joserfc/rfc7518/ec_key.py
+++ b/src/joserfc/rfc7518/ec_key.py
@@ -45,7 +45,7 @@ class ECBinding(CryptographyBinding):
     @classmethod
     def generate_private_key(cls, name: str) -> EllipticCurvePrivateKey:
         if name not in cls._dss_curves:
-            raise ValueError('Invalid crv value: "{}"'.format(name))
+            raise ValueError("Invalid crv value: '{}'".format(name))
 
         curve = cls._dss_curves[name]()
         raw_key = generate_private_key(

--- a/src/joserfc/rfc7518/jws_algs.py
+++ b/src/joserfc/rfc7518/jws_algs.py
@@ -122,7 +122,7 @@ class ECAlgModel(JWSAlgModel):
 
     def _check_key(self, key: ECKey) -> ECKey:
         if key.curve_name != self.curve:
-            raise ValueError(f'Key for "{self.name}" not supported, only "{self.curve}" allowed')
+            raise ValueError(f"Key for '{self.name}' not supported, only '{self.curve}' allowed")
         return key
 
     def sign(self, msg: bytes, key: ECKey) -> bytes:

--- a/src/joserfc/rfc7797/registry.py
+++ b/src/joserfc/rfc7797/registry.py
@@ -19,4 +19,4 @@ def _safe_b64_header(header: Header) -> bool:
     crit = header.get("crit")
     if isinstance(crit, list) and "b64" in crit:
         return True
-    raise ValueError('The "crit" Header Parameter MUST be included with "b64"')
+    raise ValueError("The 'crit' Header Parameter MUST be included with 'b64'")

--- a/src/joserfc/rfc8037/okp_key.py
+++ b/src/joserfc/rfc8037/okp_key.py
@@ -129,7 +129,7 @@ class OKPKey(CurveKey[PrivateOKPKey, PublicOKPKey]):
         :param auto_kid: add ``kid`` automatically
         """
         if crv not in PRIVATE_KEYS_MAP:
-            raise ValueError('Invalid crv value: "{}"'.format(crv))
+            raise ValueError("Invalid crv value: '{}'".format(crv))
 
         private_key_cls: t.Type[PrivateOKPKey] = PRIVATE_KEYS_MAP[crv]
         raw_key = private_key_cls.generate()


### PR DESCRIPTION
Avoid to use double quotes in error descriptions, as they are outside the authorized character set defined by RFC6749.
Related to https://github.com/lepture/authlib/issues/720 and https://github.com/lepture/authlib/pull/728