### PR TITLE
Add `KeySet` functionality to aid key rotation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ Unreleased
 
 - Use "import as" to prioritize the modules for editors.
 - Added parameter ``encoder_cls`` for ``jwt.encode`` and ``decoder_cls`` for ``jwt.decode``.
+- Added ``generate_new_key`` and ``remove_keys`` methods on ``jwk.KeySet``
 
 **Breaking changes**:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Unreleased
 - Use "import as" to prioritize the modules for editors.
 - Added parameter ``encoder_cls`` for ``jwt.encode`` and ``decoder_cls`` for ``jwt.decode``.
 - Added ``generate_new_key`` and ``remove_keys`` methods on ``jwk.KeySet``
+- Added additional ``jrfc_created_at`` and ``jrfc_disabled`` fields to ``KeyParameters`` to aid key rotation
 
 **Breaking changes**:
 

--- a/docs/guide/key-rotation.rst
+++ b/docs/guide/key-rotation.rst
@@ -1,0 +1,128 @@
+:description: Simple example of key rotation using ``joserfc``
+
+Key Rotation
+============
+
+``joserfc`` provides functionality to help implement key rotation in your
+application.
+
+Disabling keys
+--------------
+
+``BaseKey`` has a ``jrfc_disabled`` property which, if set to ``True``, will
+prevent the key from being selected by ``KeySet.pick_random_key`` and used for
+encrypting or signing tokens. It may still be used for decrypting or verifying
+tokens. This allows keys to be removed from the ``KeySet`` safely; once a key
+has been disabled on every host that creates tokens for the lifetime of your
+tokens, it may be removed from the ``KeySet``.
+
+.. code-block:: python
+
+    import json
+
+    with open("your-jwks.json") as f:
+        data = json.load(f)
+        key_set = KeySet.import_key_set(data)
+
+    oldest_key = sorted(key_set, key=lambda k: k.get("jrfc_created_at"))[0]
+    oldest_key.jrfc_disabled = True
+
+
+Managing KeySets
+----------------
+
+Below is a simple command line program that can create keysets and perform
+key rotation.
+
+.. code-block:: python
+
+    # manage-keyset.py
+    import argparse
+    import json
+    import sys
+    import time
+    from enum import StrEnum, auto
+
+    from joserfc import jwk
+
+    class Command(StrEnum):
+        GENERATE = auto()
+        ADD = auto()
+        REMOVE = auto()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", type=str, choices=[c.value for c in Command])
+    parser.add_argument("keyset_file", type=str)
+    parser.add_argument("--kid", type=str)
+    parser.add_argument("--remove-oldest", action="store_true")
+    parser.add_argument("--disable", action="store_true", help="Disable keys instead of removing them")
+
+    args = parser.parse_args()
+    args._print_help = parser.print_help
+
+    def write_keyset(keyset: jwk.KeySet, keyset_file: str):
+        with open(keyset_file, "wt") as f:
+            json.dump(keyset.as_dict(), f)
+
+    def read_keyset(keyset_file: str) -> jwk.KeySet:
+        with open(keyset_file, "r") as f:
+            return jwk.KeySet.import_key_set(json.load(f))
+
+    def run_generate(args):
+        extra_params = {"alg": "dir", "jrfc_created_at": int(time.time())}
+        keyset = jwk.KeySet.generate_key_set("oct", 256, extra_params)
+        write_keyset(keyset, args.keyset_file)
+
+    def run_add(args):
+        extra_params = {"alg": "dir", "jrfc_created_at": int(time.time())}
+        if args.kid:
+            extra_params["kid"] = args.kid
+
+        keyset = read_keyset(args.keyset_file)
+        keyset.generate_new_key("oct", 256, extra_params)
+        write_keyset(keyset, args.keyset_file)
+
+    def run_remove(args):
+        if bool(args.kid) == bool(args.remove_oldest):
+            print("Error: must provide exactly one of `--kid <id>` and `--remove-oldest`")
+            args._print_help()
+            sys.exit(1)
+
+        keyset = read_keyset(args.keyset_file)
+
+        if args.kid:
+            keys_to_remove = [k for k in keyset if k.kid == args.kid]
+        elif args.remove_oldest:
+            keys_to_remove = sorted(keyset, key=lambda k: k.get("jrfc_created_at"))[:1]
+
+        if args.disable:
+            for k in keys_to_remove:
+                k.jrfc_disabled = True
+        else:
+            keyset.remove_keys(keys_to_remove)
+
+        write_keyset(keyset, args.keyset_file)
+
+    match args.command:
+        case Command.GENERATE:
+            run_generate(args)
+        case Command.ADD:
+            run_add(args)
+        case Command.REMOVE:
+            run_remove(args)
+
+Usage would look something like this:
+
+.. code-block:: bash
+
+    # Generate the keyset
+    $ python manage-keyset.py generate keyset.json
+
+    # Add a key to the keyset
+    $ python manage-keyset.py add keyset.json
+
+    # Disable the oldest key in the keyset
+    $ python manage-keyset.py remove keyset.json --remove-oldest --disable
+
+    # Remove the oldest key in the keyset
+    $ python manage-keyset.py remove keyset.json --remove-oldest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,6 +78,7 @@ Explore the following sections to discover more about ``joserfc`` and its featur
    guide/index
    guide/algorithms
    guide/registry
+   guide/key-rotation
    migrations/index
 
 .. toctree::

--- a/src/joserfc/_keys.py
+++ b/src/joserfc/_keys.py
@@ -155,6 +155,19 @@ class KeySet:
             return random.choice(keys)
         return None
 
+    def generate_new_key(
+            self,
+            key_type: str,
+            crv_or_size: str | int,
+            parameters: KeyParameters | None = None,
+            private: bool = True) -> Key:
+        new_key = self.registry_cls.generate_key(key_type, crv_or_size, parameters, private, auto_kid)
+        self.keys.append(new_key)
+        return new_key
+
+    def remove_keys(self, keys_to_remove: list[Key]):
+        self.keys = [k for k in self.keys if k not in keys_to_remove]
+
     @classmethod
     def import_key_set(
             cls,

--- a/src/joserfc/_keys.py
+++ b/src/joserfc/_keys.py
@@ -148,9 +148,9 @@ class KeySet:
     def pick_random_key(self, algorithm: str) -> t.Optional[Key]:
         key_types = self.algorithm_keys.get(algorithm)
         if key_types:
-            keys = [k for k in self.keys if k.key_type in key_types]
+            keys = [k for k in self.keys if k.key_type in key_types and not k.jrfc_disabled]
         else:
-            keys = self.keys
+            keys = [k for k in self.keys if not k.jrfc_disabled]
         if keys:
             return random.choice(keys)
         return None

--- a/src/joserfc/rfc7517/models.py
+++ b/src/joserfc/rfc7517/models.py
@@ -160,6 +160,22 @@ class BaseKey(t.Generic[NativePrivateKey, NativePublicKey], metaclass=ABCMeta):
     def private_key(self) -> t.Optional[NativePrivateKey]:
         raise NotImplementedError()
 
+    @property
+    def jrfc_disabled(self) -> t.Optional[bool]:
+        """
+        The "jrfc_disabled" custom value of the JSON Web Key, or ``False``
+        if not present.
+        """
+        return t.cast(t.Optional[str], self.get("jrfc_disabled", False))
+
+    @jrfc_disabled.setter
+    def jrfc_disabled(self, value: bool):
+        self.dict_value["jrfc_disabled"] = value
+
+    @jrfc_disabled.deleter
+    def jrfc_disabled(self):
+        del self.dict_value["jrfc_disabled"]
+
     def thumbprint(self) -> str:
         """Call this method will generate the thumbprint with algorithm
         defined in RFC7638."""

--- a/src/joserfc/rfc7517/types.py
+++ b/src/joserfc/rfc7517/types.py
@@ -8,8 +8,8 @@ DictKey = t.Dict[str, t.Union[str, t.List[str]]]
 #: Key in str, bytes and dict
 AnyKey = t.Union[str, bytes, DictKey]
 
-#: extra key parameters for JWK
-KeyParameters = t.TypedDict("KeyParameters", {
+#: extra key parameters for JWK as defined in RFC7517
+RFC7517KeyParameters = t.TypedDict("RFC7517KeyParameters", {
     "use": str,
     "key_ops": t.List[str],
     "alg": str,
@@ -19,3 +19,16 @@ KeyParameters = t.TypedDict("KeyParameters", {
     "x5t": str,
     "x5t#S256": str,
 }, total=False)
+
+class KeyParameters(RFC7517KeyParameters, total=False):
+    """
+    RFC7517-defined key parameters supplemented by ``joserfc``-specific metadata.
+    """
+    # Unix timestamp at which the key was created.
+    jrfc_created_at: int
+
+    # Boolean indicating whether the key may be used for encryption. If ``True``, the key may
+    # not be used for encryption but may still be used for decryption. If ``False``, the key
+    # may be used for either operation.
+    jrfc_disabled: bool
+


### PR DESCRIPTION
[RFC]

i was beginning to build key rotation on top of my usage of `joserfc`'s JWEs but i thought it was simple enough that i should reach out to see if upstream wants something like this. if you like this direction i would be happy to write tests and iterate over details in review

this change is broken into three commits, described below. no worries if you are not interested, and let me know if you have any feedback!

thank you for this project, by the way!

### [feat: generate_new_key() and remove_keys() for KeySet](https://github.com/authlib/joserfc/commit/cc813678190c30b04e9f53102aaf2b3688925298)

it's not clear to me whether users are allowed to manipulate `key_set.keys` directly so i added some instance methods that add/remove keys in an existing `KeySet`.

because users _are_ allowed to iterate over a `KeySet`'s keys, this part is enough to write a basic key rotation tool. users can use sequential `kid`s to add and remove keys based on age or come up with some other scheme.

### [feat: add additional metadata in KeyParameters to aid key rotation](https://github.com/authlib/joserfc/commit/033adfcbae6e1c255cb02f69c6a3c4fbb7f0ca47)

this change is more opinionated. it adds two new JWK parameters to `KeyParameters`:
- `jrfc_created_at`, a UTC unix timestamp indicating when the key was created
  - this is not actually used in `joserfc` at all, it's just there so users who want to rotate keys on a schedule can reliably order their keys by age. users bring their own timestamps, like they would bring their own `kid`s
  - alternatives:
    - if `joserfc` always inserts keys in the same position in the list, and the list's order is stable, documentation could instruct users to rely on that ordering
    - users can supply sequential `kid`s for each key they add and order them that way
    - users can ignore the typechecker and just put extra fields in the `TypedDict`
- `jrfc_disabled`, a boolean indicating whether the key should be used to create new tokens
  - this is a `KeyParameters` attribute as well as a mutable property on `BaseKey`. if it's `True`, the key will not be selected in `pick_random_key()` and not be used to create new tokens unless explicitly passed in. it may still be used to decrypt or verify incoming tokens.
  - the idea here is: i want to disable a key, wait until all tokens issued with it have expired, and then remove the key

### [docs: add guide page for key rotation](https://github.com/authlib/joserfc/commit/105499abc9e979dbc7c9fa5f06d1a4ceeb093ffa)

i wrote a new guide page with an example program that can be used to implement key rotation:
- `python manage-keyset.py generate keyset.json` to generate a new keyset and save to `keyset.json`
- `python manage-keyset.py add keyset.json` to generate a new key and add it to `keyset.json`
- `python manage-keyset.py remove keyset.json --remove-oldest --disable` to disable the oldest key
- `python manage-keyset.py remove keyset.json --remove-oldest` to remove the oldest key, which was disabled

plug the script into a cron system and a way to synchronize `keyset.json` across hosts and you're good.