### PR TITLE
Make GuestProtocol and KeyBase public

### DIFF
--- a/src/joserfc/jwk.py
+++ b/src/joserfc/jwk.py
@@ -24,6 +24,8 @@ __all__ = [
     "ECKey",
     "OKPKey",
     "KeySet",
+    "KeyBase",
+    "GuestProtocol",
     "guess_key",
 ]
 


### PR DESCRIPTION
This PR adds `GuestProtocol` and `KeyBase` to the module's `__all__`, making them explicitly part of the public API.

No functional changes are introduced; this PR only updates the module’s public API declaration.

### Rationale

- `guess_key()` is already public and accepts an argument of type `obj: GuestProtocol`. Making `GuestProtocol` public improves consistency and supports clearer type usage.
- Likewise, `KeyCallable` is a public type that uses `KeyBase` as its return type. Including `KeyBase` in the public API ensures that all referenced types are accessible to users.

This change helps maintain a coherent and discoverable API surface, especially for users (like me) using static analysis or type checking tools.
