### PR TITLE
feat: use `InvalidHeaderValueError` in registry header validation

### DIFF
--- a/docs/guide/jwt.rst
+++ b/docs/guide/jwt.rst
@@ -291,7 +291,7 @@ Algorithms & Registry
 
 The :meth:`encode` and :meth:`decode` accept an ``algorithms`` parameter for
 specifying the allowed algorithms. By default, it only allows your to use
-recommended algorithms.
+**recommended** algorithms.
 
 You can find out the recommended algorithms at:
 

--- a/docs/guide/registry.rst
+++ b/docs/guide/registry.rst
@@ -73,13 +73,13 @@ the value type.
     >>> jws.serialize_compact({"alg": "HS256", "kid": 123}, "hello", key)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-      File "$/joserfc/jws.py", line 98, in serialize_compact
+      File ".../joserfc/jws.py", line 111, in serialize_compact
         registry.check_header(protected)
-      File "$/joserfc/rfc7515/registry.py", line 63, in check_header
+      File ".../joserfc/rfc7515/registry.py", line 68, in check_header
         validate_registry_header(self.header_registry, header)
-      File "$/joserfc/registry.py", line 193, in validate_registry_header
-        raise ValueError(f'"{key}" in header {error}')
-    ValueError: "kid" in header must be a str
+      File ".../joserfc/registry.py", line 194, in validate_registry_header
+        raise InvalidHeaderValueError(f"'{key}' in header {error}")
+    joserfc.errors.InvalidHeaderValueError: invalid_header_value: 'kid' in header must be a str
 
 In the above example, ``kid`` MUST be a string instead of an integer. The default
 registry validates the ``kid`` before processing the serialization.

--- a/docs/guide/registry.rst
+++ b/docs/guide/registry.rst
@@ -99,13 +99,13 @@ indicating that they must be present. For example:
     >>> jws.serialize_compact({"alg": "HS256", "crit": ["kid"]}, "hello", key)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-      File "$/joserfc/jws.py", line 98, in serialize_compact
+      File ".../joserfc/jws.py", line 111, in serialize_compact
         registry.check_header(protected)
-      File "$/joserfc/rfc7515/registry.py", line 62, in check_header
+      File ".../joserfc/rfc7515/registry.py", line 67, in check_header
         check_crit_header(header)
-      File "$/joserfc/registry.py", line 195, in check_crit_header
-        raise ValueError(f'"{k}" is a critical header')
-    ValueError: "kid" is a critical header
+      File ".../joserfc/registry.py", line 202, in check_crit_header
+        raise MissingCritHeaderError(k)
+    joserfc.errors.MissingCritHeaderError: missing_crit_header: Missing critical 'kid' value in header
 
 Since "kid" is listed as a critical (``crit``) header parameter, it is mandatory
 and must be included in the header.
@@ -124,13 +124,13 @@ Any additional header beyond those supported by the algorithm will result in an 
     >>> jws.serialize_compact({"alg": "HS256", "custom": "hi"}, "hello", key)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-      File "/home/lepture/authlib/joserfc/src/joserfc/jws.py", line 98, in serialize_compact
+      File ".../joserfc/jws.py", line 111, in serialize_compact
         registry.check_header(protected)
-      File "/home/lepture/authlib/joserfc/src/joserfc/rfc7515/registry.py", line 65, in check_header
+      File ".../joserfc/rfc7515/registry.py", line 70, in check_header
         check_supported_header(self.header_registry, header)
-      File "/home/lepture/authlib/joserfc/src/joserfc/registry.py", line 175, in check_supported_header
-        raise ValueError(f'Unsupported "{unsupported_keys} in header')
-    ValueError: Unsupported {'custom'} in header
+      File ".../joserfc/registry.py", line 183, in check_supported_header
+        raise UnsupportedHeaderError(f"Unsupported {unsupported_keys} in header")
+    joserfc.errors.UnsupportedHeaderError: unsupported_header: Unsupported {'custom'} in header
 
 To resolve this error, you have two options. First, you can register the
 additional header parameters with the registry. This allows the registry

--- a/docs/locales/zh/LC_MESSAGES/api.po
+++ b/docs/locales/zh/LC_MESSAGES/api.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  joserfc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-28 11:54+0900\n"
+"POT-Creation-Date: 2025-04-20 18:35+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh\n"
@@ -43,24 +43,44 @@ msgstr "该错误是为 JWS/JWT 设计的，当签名不匹配时触发。"
 #: joserfc.errors.InvalidEncryptedKeyError.error:1
 #: joserfc.errors.InvalidEncryptionAlgorithmError.error:1
 #: joserfc.errors.InvalidExchangeKeyError.error:1
+#: joserfc.errors.InvalidHeaderValueError.error:1
+#: joserfc.errors.InvalidKeyIdError.error:1
 #: joserfc.errors.InvalidKeyLengthError.error:1
 #: joserfc.errors.InvalidKeyTypeError.error:1
 #: joserfc.errors.InvalidPayloadError.error:1
 #: joserfc.errors.InvalidTokenError.error:1 joserfc.errors.JoseError.error:1
 #: joserfc.errors.MissingAlgorithmError.error:1
 #: joserfc.errors.MissingClaimError.error:1
+#: joserfc.errors.MissingCritHeaderError.error:1
 #: joserfc.errors.MissingEncryptionError.error:1
+#: joserfc.errors.MissingHeaderError.error:1
+#: joserfc.errors.MissingKeyError.error:1
+#: joserfc.errors.MissingKeyTypeError.error:1
+#: joserfc.errors.UnsupportedAlgorithmError.error:1
+#: joserfc.errors.UnsupportedHeaderError.error:1
 #: joserfc.errors.UnsupportedKeyAlgorithmError.error:1
 #: joserfc.errors.UnsupportedKeyOperationError.error:1
 #: joserfc.errors.UnsupportedKeyUseError.error:1 of
 msgid "short-string error code"
 msgstr "短字符串错误代码"
 
+#: joserfc.errors.DecodeError:1 of
+#, fuzzy
+msgid ""
+"This error is designed for JWS/JWE. It is raised when deserialization and"
+" decryption fails."
+msgstr "该错误是为 JWS/JWT 设计的，当签名不匹配时触发。"
+
 #: joserfc.errors.ExceededSizeError:1 of
 msgid ""
 "This error is designed for DEF zip algorithm. It raised when the "
 "compressed data exceeds the maximum allowed length."
 msgstr "该错误是为 DEF 压缩算法设计的，当压缩数据超过允许的最大长度时触发。"
+
+#: joserfc.errors.ExpiredTokenError:1 of
+#, fuzzy
+msgid "This error is designed for JWT. It raised when the token is expired."
+msgstr "该错误是为 JWS/JWT 设计的，当签名不匹配时触发。"
 
 #: ../../docstring joserfc.errors.ExpiredTokenError.description:1
 #: joserfc.errors.InvalidCEKLengthError.description:1
@@ -73,15 +93,63 @@ msgstr "该错误是为 DEF 压缩算法设计的，当压缩数据超过允许�
 msgid "long-string to describe this error"
 msgstr "描述此错误的长字符串"
 
+#: joserfc.errors.InsecureClaimError:1 of
+#, fuzzy
+msgid ""
+"This error is designed for JWT. It raised when the claim contains "
+"sensitive information."
+msgstr "该错误是为 JWS/JWT 设计的，当签名不匹配时触发。"
+
+#: joserfc.errors.InvalidClaimError:1 of
+#, fuzzy
+msgid ""
+"This error is designed for JWT. It raised when the claim contains invalid"
+" values or types."
+msgstr "该错误是为 JWS/JWT 设计的，当签名不匹配时触发。"
+
 #: joserfc.errors.InvalidEncryptionAlgorithmError:1 of
 msgid ""
 "This error is designed for JWE. It is raised when \"enc\" value does not "
 "work together with \"alg\" value."
 msgstr "该错误是为 JWE 设计的，当 \"enc\" 值与 \"alg\" 值不兼容时触发。"
 
+#: joserfc.errors.InvalidPayloadError:1 of
+#, fuzzy
+msgid ""
+"This error is designed for JWT. It raised when the payload is not a valid"
+" JSON object."
+msgstr "该错误是为 JWS/JWT 设计的，当签名不匹配时触发。"
+
+#: joserfc.errors.InvalidTokenError:1 of
+#, fuzzy
+msgid "This error is designed for JWT. It raised when the token is not valid yet."
+msgstr "该错误是为 JWS/JWT 设计的，当签名不匹配时触发。"
+
 #: joserfc.errors.JoseError:1 of
 msgid "Base Exception for all errors in joserfc."
 msgstr "joserfc 中所有错误的基类异常。"
+
+#: joserfc.errors.MissingClaimError:1 of
+#, fuzzy
+msgid ""
+"This error is designed for JWT. It raised when the required claims are "
+"missing."
+msgstr "该错误是为 JWS/JWT 设计的，当签名不匹配时触发。"
+
+#: joserfc.errors.MissingCritHeaderError:1 of
+msgid "This error happens when the critical header does not exist."
+msgstr ""
+
+#: joserfc.errors.MissingEncryptionError:1 of
+#, fuzzy
+msgid ""
+"This error is designed for JWE. It is raised when the 'enc' value in "
+"header is missing."
+msgstr "该错误是为 JWE 设计的，当 \"enc\" 值与 \"alg\" 值不兼容时触发。"
+
+#: joserfc.errors.MissingHeaderError:1 of
+msgid "This error happens when the required header does not exist."
+msgstr ""
 
 #: ../../api/index.rst:2
 msgid "API References"
@@ -729,8 +797,8 @@ msgid ""
 "represents digitally signed or MACed content as a JSON object. This "
 "representation is neither optimized for compactness nor URL-safe."
 msgstr ""
-"生成 JWS JSON 序列化（字典形式）。JWS JSON 序列化将数字签名或 MAC 内容表示为 JSON 对象。"
-"此表示既不优化紧凑性，也不 URL 安全。"
+"生成 JWS JSON 序列化（字典形式）。JWS JSON 序列化将数字签名或 MAC 内容表示为 JSON 对象。此表示既不优化紧凑性，也不 "
+"URL 安全。"
 
 #: joserfc.jws.serialize_json:5 of
 msgid "A general JWS JSON Serialization contains:"
@@ -876,6 +944,10 @@ msgid "a ``JWSRegistry`` or ``JWERegistry`` to use"
 msgstr "要使用的 ``JWSRegistry`` 或 ``JWERegistry``"
 
 #: joserfc.jwt.decode:8 of
+msgid "A JSONDecoder subclass to use"
+msgstr ""
+
+#: joserfc.jwt.decode:9 of
 msgid "BadSignatureError"
 msgstr "BadSignatureError"
 
@@ -894,4 +966,8 @@ msgstr "用来编码的字典形式的 JWT claims 部分"
 #: joserfc.jwt.encode:5 of
 msgid "key used to sign the signature"
 msgstr "用于签名的密钥"
+
+#: joserfc.jwt.encode:8 of
+msgid "A JSONEncoder subclass to use"
+msgstr ""
 

--- a/docs/locales/zh/LC_MESSAGES/changelog.po
+++ b/docs/locales/zh/LC_MESSAGES/changelog.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  joserfc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-28 11:54+0900\n"
+"POT-Creation-Date: 2025-04-20 18:35+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh\n"
@@ -28,351 +28,389 @@ msgid "Here is the history of joserfc_ package releases."
 msgstr "这里记录了 joserfc_ 的发布历史。"
 
 #: ../../changelog.rst:16
-msgid "1.0.4"
+msgid "Unreleased"
 msgstr ""
 
 #: ../../changelog.rst:18
-msgid "**Released on Feb 28, 2025**"
+msgid "Use \"import as\" to prioritize the modules for editors."
+msgstr ""
+
+#: ../../changelog.rst:19
+msgid ""
+"Added parameter ``encoder_cls`` for ``jwt.encode`` and ``decoder_cls`` "
+"for ``jwt.decode``."
 msgstr ""
 
 #: ../../changelog.rst:20
+msgid "Added ``none`` algorithm for JWS."
+msgstr ""
+
+#: ../../changelog.rst:22 ../../changelog.rst:135
+msgid "**Breaking changes**:"
+msgstr ""
+
+#: ../../changelog.rst:24
+msgid "Use ``ECKey.binding.register_curve`` to register new supported curves."
+msgstr ""
+
+#: ../../changelog.rst:25
+msgid ""
+"Use ``UnsupportedAlgorithmError`` instead of ``ValueError`` in JWS/JWE "
+"registry."
+msgstr ""
+
+#: ../../changelog.rst:26
+msgid "Use ``MissingKeyTypeError`` and ``InvalidKeyIdError`` for errors in JWK."
+msgstr ""
+
+#: ../../changelog.rst:27
+msgid ""
+"Use ``UnsupportedHeaderError``, ``MissingHeaderError``, and "
+"``MissingCritHeaderError`` for header validation."
+msgstr ""
+
+#: ../../changelog.rst:28
+msgid "Respect RFC6749 character set in error descriptions."
+msgstr ""
+
+#: ../../changelog.rst:31
+msgid "1.0.4"
+msgstr ""
+
+#: ../../changelog.rst:33
+msgid "**Released on Feb 28, 2025**"
+msgstr ""
+
+#: ../../changelog.rst:35
 msgid "Use secrets module to generate random bytes."
 msgstr ""
 
-#: ../../changelog.rst:21
+#: ../../changelog.rst:36
 msgid ""
 "Use warnings for possible unsafe ``OctKey``` instead of raising error, "
 "via :issue:`32`."
 msgstr ""
 
-#: ../../changelog.rst:24
+#: ../../changelog.rst:39
 msgid "1.0.3"
 msgstr ""
 
-#: ../../changelog.rst:26
+#: ../../changelog.rst:41
 msgid "**Released on Feb 6, 2025**"
 msgstr ""
 
-#: ../../changelog.rst:28
+#: ../../changelog.rst:43
 msgid "Allow using sha256, sha384, sha512 hash functions in thumbprint (RFC7638)."
 msgstr ""
 
-#: ../../changelog.rst:31
+#: ../../changelog.rst:46
 msgid "1.0.2"
 msgstr ""
 
-#: ../../changelog.rst:33
+#: ../../changelog.rst:48
 msgid "**Released on Jan 20, 2025**"
 msgstr ""
 
-#: ../../changelog.rst:35
+#: ../../changelog.rst:50
 msgid "Support import key from a certificate pem file."
 msgstr ""
 
-#: ../../changelog.rst:38
+#: ../../changelog.rst:53
 msgid "1.0.1"
 msgstr ""
 
-#: ../../changelog.rst:40
+#: ../../changelog.rst:55
 msgid "**Released on December 3, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:42
+#: ../../changelog.rst:57
 msgid "Throw an error on non-valid base64 strings."
 msgstr ""
 
-#: ../../changelog.rst:45
+#: ../../changelog.rst:60
 msgid "1.0.0"
 msgstr ""
 
-#: ../../changelog.rst:47
+#: ../../changelog.rst:62
 msgid "**Released on July 14, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:49
+#: ../../changelog.rst:64
 msgid "Fix type hints for strict mode."
 msgstr ""
 
-#: ../../changelog.rst:52
+#: ../../changelog.rst:67
 msgid "0.12.0"
 msgstr ""
 
-#: ../../changelog.rst:54
+#: ../../changelog.rst:69
 msgid "**Released on June 15, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:56
+#: ../../changelog.rst:71
 msgid "Limit DEF decompress size to 250k bytes."
 msgstr ""
 
-#: ../../changelog.rst:57
+#: ../../changelog.rst:72
 msgid "Fix claims validation, via :issue:`23`."
 msgstr ""
 
-#: ../../changelog.rst:60
+#: ../../changelog.rst:75
 msgid "0.11.1"
 msgstr ""
 
-#: ../../changelog.rst:62 ../../changelog.rst:69
+#: ../../changelog.rst:77 ../../changelog.rst:84
 msgid "**Released on June 4, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:64
+#: ../../changelog.rst:79
 msgid "Remove validating ``typ`` header with ``jwt.decode`` method."
 msgstr ""
 
-#: ../../changelog.rst:67
+#: ../../changelog.rst:82
 msgid "0.11.0"
 msgstr ""
 
-#: ../../changelog.rst:71
+#: ../../changelog.rst:86
 msgid "``jwe.decrypt_json`` allows to verify only one recipient."
 msgstr ""
 
-#: ../../changelog.rst:72
+#: ../../changelog.rst:87
 msgid "Prevent ``OctKey`` to import ``ssh-dss``."
 msgstr ""
 
-#: ../../changelog.rst:73
+#: ../../changelog.rst:88
 msgid "Deprecate use of string and bytes as key."
 msgstr ""
 
-#: ../../changelog.rst:76
+#: ../../changelog.rst:91
 msgid "0.10.0"
 msgstr ""
 
-#: ../../changelog.rst:78
+#: ../../changelog.rst:93
 msgid "**Released on May 13, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:80
+#: ../../changelog.rst:95
 msgid "Change ``jwt.encode`` and ``jwt.decode`` to use JWS by default."
 msgstr ""
 
-#: ../../changelog.rst:83
+#: ../../changelog.rst:98
 msgid "0.9.0"
 msgstr ""
 
-#: ../../changelog.rst:85
+#: ../../changelog.rst:100
 msgid "**Released on November 16, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:87
+#: ../../changelog.rst:102
 msgid "Use ``os.urandom`` for ``OctKey.generate_key``."
 msgstr ""
 
-#: ../../changelog.rst:88
+#: ../../changelog.rst:103
 msgid "Add ``allow_blank`` for ``JWTClaimsRegistry``."
 msgstr ""
 
-#: ../../changelog.rst:89
+#: ../../changelog.rst:104
 msgid "Improve callable key for :meth:`~jwk.guess_key`."
 msgstr ""
 
-#: ../../changelog.rst:92
+#: ../../changelog.rst:107
 msgid "0.8.0"
 msgstr ""
 
-#: ../../changelog.rst:94
+#: ../../changelog.rst:109
 msgid "**Released on September 06, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:96
+#: ../../changelog.rst:111
 msgid "Add :ref:`ensure_kid` method on key models."
 msgstr ""
 
-#: ../../changelog.rst:97
+#: ../../changelog.rst:112
 msgid "Add ``auto_kid`` parameter on key model ``.generate_key`` method."
 msgstr ""
 
-#: ../../changelog.rst:98 ../../changelog.rst:108
+#: ../../changelog.rst:113 ../../changelog.rst:123
 msgid "Improvements on type hints"
 msgstr ""
 
-#: ../../changelog.rst:101
+#: ../../changelog.rst:116
 msgid "0.7.0"
 msgstr ""
 
-#: ../../changelog.rst:103
+#: ../../changelog.rst:118
 msgid "**Released on August 14, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:105
+#: ../../changelog.rst:120
 msgid "Add \"iat\" claims validation in JWT."
 msgstr ""
 
-#: ../../changelog.rst:106
+#: ../../changelog.rst:121
 msgid "Add ``__bool__`` magic method on :class:`jwk.KeySet`."
 msgstr ""
 
-#: ../../changelog.rst:107
+#: ../../changelog.rst:122
 msgid ""
 "Raise ``InvalidExchangeKeyError`` for ``exchange_derive_key`` on Curve "
 "key."
 msgstr ""
 
-#: ../../changelog.rst:111
+#: ../../changelog.rst:126
 msgid "0.6.0"
 msgstr ""
 
-#: ../../changelog.rst:113
+#: ../../changelog.rst:128
 msgid "**Released on July 20, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:115
+#: ../../changelog.rst:130
 msgid "Huge improvements on type hints, via :user:`Viicos`."
 msgstr ""
 
-#: ../../changelog.rst:116
+#: ../../changelog.rst:131
 msgid "Do not mutate the header when ``jwt.encode``, via :issue:`6`."
 msgstr ""
 
-#: ../../changelog.rst:117
+#: ../../changelog.rst:132
 msgid "Register algorithms with their matched key types on key set."
 msgstr ""
 
-#: ../../changelog.rst:118
+#: ../../changelog.rst:133
 msgid "Improve error handling, raise proper errors."
 msgstr ""
 
-#: ../../changelog.rst:120
-msgid "**Breaking changes**:"
-msgstr ""
-
-#: ../../changelog.rst:122
+#: ../../changelog.rst:137
 msgid ""
 "``jws.JSONSignature`` is replaced by :class:`jws.GeneralJSONSignature` "
 "and :class:`jws.FlattenedJSONSignature`."
 msgstr ""
 
-#: ../../changelog.rst:124
+#: ../../changelog.rst:139
 msgid ""
 "``jwe.JSONEncryption`` is replaced by :class:`jwe.GeneralJSONEncryption` "
 "and :class:`jwe.FlattenedJSONEncryption`."
 msgstr ""
 
-#: ../../changelog.rst:128
+#: ../../changelog.rst:143
 msgid "0.5.0"
 msgstr ""
 
-#: ../../changelog.rst:130
+#: ../../changelog.rst:145
 msgid "**Released on July 12, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:132
+#: ../../changelog.rst:147
 msgid "Add RFC7797 JSON Web Signature (JWS) Unencoded Payload Option"
 msgstr ""
 
-#: ../../changelog.rst:133
+#: ../../changelog.rst:148
 msgid "Fix ``decrypt_json`` when there is no ``encrypted_key``"
 msgstr ""
 
-#: ../../changelog.rst:134
+#: ../../changelog.rst:149
 msgid "Rename JWE CompleteJSONSerialization to GeneralJSONSerialization"
 msgstr ""
 
-#: ../../changelog.rst:135
+#: ../../changelog.rst:150
 msgid "Rename ``JSONEncryption.flatten`` to ``.flattened``"
 msgstr ""
 
-#: ../../changelog.rst:136
+#: ../../changelog.rst:151
 msgid "Load and dump RSA, EC, and OKP key with password"
 msgstr ""
 
-#: ../../changelog.rst:137
+#: ../../changelog.rst:152
 msgid ""
 "Rename Curve key method: ``exchange_shared_key`` to "
 "``exchange_derive_key``"
 msgstr ""
 
-#: ../../changelog.rst:140
+#: ../../changelog.rst:155
 msgid "0.4.0"
 msgstr ""
 
-#: ../../changelog.rst:142
+#: ../../changelog.rst:157
 msgid "**Released on July 6, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:144
+#: ../../changelog.rst:159
 msgid "Change ``options`` to ``parameters`` for JWK methods"
 msgstr ""
 
-#: ../../changelog.rst:145
+#: ../../changelog.rst:160
 msgid "Change ``JWSRegistry`` and ``JWERegistry`` parameters"
 msgstr ""
 
-#: ../../changelog.rst:146
+#: ../../changelog.rst:161
 msgid "Guess ``sender_key`` from JWKs in JWE"
 msgstr ""
 
-#: ../../changelog.rst:147
+#: ../../changelog.rst:162
 msgid "Add importing key from DER encoding bytes"
 msgstr ""
 
-#: ../../changelog.rst:148
+#: ../../changelog.rst:163
 msgid "Fix JWS JSON serialization when members have only unprotected headers"
 msgstr ""
 
-#: ../../changelog.rst:149
+#: ../../changelog.rst:164
 msgid "Check key type before processing algorithms of JWS and JWE"
 msgstr ""
 
-#: ../../changelog.rst:152
+#: ../../changelog.rst:167
 msgid "0.3.0"
 msgstr ""
 
-#: ../../changelog.rst:154
+#: ../../changelog.rst:169
 msgid "**Released on June 29, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:156
+#: ../../changelog.rst:171
 msgid "Return ``str`` instead of ``bytes`` for JWS and JWE serializations"
 msgstr ""
 
-#: ../../changelog.rst:157
+#: ../../changelog.rst:172
 msgid "Add a ``detach_content`` method for JWS"
 msgstr ""
 
-#: ../../changelog.rst:158
+#: ../../changelog.rst:173
 msgid "Remove ``jwt.extract`` method, because ``extract`` won't work for JWE"
 msgstr ""
 
-#: ../../changelog.rst:159
+#: ../../changelog.rst:174
 msgid "Add ``JWKRegistry`` for JWK"
 msgstr ""
 
-#: ../../changelog.rst:160
+#: ../../changelog.rst:175
 msgid "Update ``JSONEncryption.add_recipient`` parameters"
 msgstr ""
 
-#: ../../changelog.rst:161
+#: ../../changelog.rst:176
 msgid "Export register methods for JWE drafts"
 msgstr ""
 
-#: ../../changelog.rst:164
+#: ../../changelog.rst:179
 msgid "0.2.0"
 msgstr ""
 
-#: ../../changelog.rst:166
+#: ../../changelog.rst:181
 msgid "**Released on June 25, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:168
+#: ../../changelog.rst:183
 msgid "A beta release."
 msgstr ""
 
-#: ../../changelog.rst:171
+#: ../../changelog.rst:186
 msgid "0.1.0"
 msgstr ""
 
-#: ../../changelog.rst:173
+#: ../../changelog.rst:188
 msgid "**Released on March 5, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:175
+#: ../../changelog.rst:190
 msgid "Initial release."
 msgstr ""
-
-#~ msgid "Fix claims validation, , via :issue:`23`."
-#~ msgstr ""
-

--- a/docs/locales/zh/LC_MESSAGES/guide.po
+++ b/docs/locales/zh/LC_MESSAGES/guide.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  joserfc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-28 11:54+0900\n"
+"POT-Creation-Date: 2025-04-20 18:35+0900\n"
 "PO-Revision-Date: 2023-07-15 14:44+0900\n"
 "Last-Translator: Hsiaoming Yang <me@lepture.com>\n"
 "Language: zh\n"
@@ -78,16 +78,16 @@ msgid ""
 "RFC8812. You MUST specify the correct key type for each algorithm."
 msgstr "``joserfc.jws`` 模块支持 RFC7518、RFC8037 和 RFC8812 中的算法。您必须为每个算法指定正确的密钥类型。"
 
-#: ../../guide/algorithms.rst:37 ../../guide/algorithms.rst:68
+#: ../../guide/algorithms.rst:37 ../../guide/algorithms.rst:85
 #: ../../guide/jws.rst:245
 msgid "Algorithm name"
 msgstr "算法名"
 
-#: ../../guide/algorithms.rst:37 ../../guide/algorithms.rst:68
+#: ../../guide/algorithms.rst:37 ../../guide/algorithms.rst:85
 msgid "Key Type"
 msgstr "密钥类型"
 
-#: ../../guide/algorithms.rst:37 ../../guide/algorithms.rst:68
+#: ../../guide/algorithms.rst:37 ../../guide/algorithms.rst:85
 #: ../../guide/jws.rst:245
 msgid "Recommended"
 msgstr "是推荐"
@@ -98,10 +98,10 @@ msgstr ""
 
 #: ../../guide/algorithms.rst:39 ../../guide/algorithms.rst:40
 #: ../../guide/algorithms.rst:41 ../../guide/algorithms.rst:42
-#: ../../guide/algorithms.rst:70 ../../guide/algorithms.rst:71
-#: ../../guide/algorithms.rst:72 ../../guide/algorithms.rst:73
-#: ../../guide/algorithms.rst:81 ../../guide/algorithms.rst:82
-#: ../../guide/algorithms.rst:83 ../../guide/jwk.rst:19
+#: ../../guide/algorithms.rst:87 ../../guide/algorithms.rst:88
+#: ../../guide/algorithms.rst:89 ../../guide/algorithms.rst:90
+#: ../../guide/algorithms.rst:98 ../../guide/algorithms.rst:99
+#: ../../guide/algorithms.rst:100 ../../guide/jwk.rst:19
 msgid "OctKey"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 #: ../../guide/algorithms.rst:48 ../../guide/algorithms.rst:49
 #: ../../guide/algorithms.rst:50 ../../guide/algorithms.rst:51
 #: ../../guide/algorithms.rst:52 ../../guide/algorithms.rst:53
-#: ../../guide/algorithms.rst:72 ../../guide/algorithms.rst:74
-#: ../../guide/algorithms.rst:76 ../../guide/algorithms.rst:79
-#: ../../guide/algorithms.rst:81 ../../guide/algorithms.rst:82
-#: ../../guide/algorithms.rst:83 ../../guide/algorithms.rst:84
-#: ../../guide/algorithms.rst:85 ../../guide/algorithms.rst:86
+#: ../../guide/algorithms.rst:89 ../../guide/algorithms.rst:91
+#: ../../guide/algorithms.rst:93 ../../guide/algorithms.rst:96
+#: ../../guide/algorithms.rst:98 ../../guide/algorithms.rst:99
+#: ../../guide/algorithms.rst:100 ../../guide/algorithms.rst:101
+#: ../../guide/algorithms.rst:102 ../../guide/algorithms.rst:103
 #: ../../guide/jws.rst:247 ../../guide/jws.rst:249 ../../guide/jws.rst:250
 #: ../../guide/jws.rst:252 ../../guide/jws.rst:253 ../../guide/jws.rst:255
 #: ../../guide/jws.rst:256 ../../guide/jws.rst:257 ../../guide/jws.rst:258
@@ -128,10 +128,10 @@ msgid "HS256"
 msgstr ""
 
 #: ../../guide/algorithms.rst:40 ../../guide/algorithms.rst:43
-#: ../../guide/algorithms.rst:46 ../../guide/algorithms.rst:70
-#: ../../guide/algorithms.rst:71 ../../guide/algorithms.rst:73
-#: ../../guide/algorithms.rst:75 ../../guide/algorithms.rst:77
-#: ../../guide/algorithms.rst:78 ../../guide/algorithms.rst:80
+#: ../../guide/algorithms.rst:46 ../../guide/algorithms.rst:87
+#: ../../guide/algorithms.rst:88 ../../guide/algorithms.rst:90
+#: ../../guide/algorithms.rst:92 ../../guide/algorithms.rst:94
+#: ../../guide/algorithms.rst:95 ../../guide/algorithms.rst:97
 msgid ":bdg-success:`Yes`"
 msgstr ":bdg-success:`是`"
 
@@ -150,9 +150,9 @@ msgstr ""
 #: ../../guide/algorithms.rst:43 ../../guide/algorithms.rst:44
 #: ../../guide/algorithms.rst:45 ../../guide/algorithms.rst:49
 #: ../../guide/algorithms.rst:50 ../../guide/algorithms.rst:51
-#: ../../guide/algorithms.rst:74 ../../guide/algorithms.rst:75
-#: ../../guide/algorithms.rst:76 ../../guide/algorithms.rst:84
-#: ../../guide/algorithms.rst:85 ../../guide/algorithms.rst:86
+#: ../../guide/algorithms.rst:91 ../../guide/algorithms.rst:92
+#: ../../guide/algorithms.rst:93 ../../guide/algorithms.rst:101
+#: ../../guide/algorithms.rst:102 ../../guide/algorithms.rst:103
 #: ../../guide/jwk.rst:64
 msgid "RSAKey"
 msgstr ""
@@ -171,8 +171,8 @@ msgstr ""
 
 #: ../../guide/algorithms.rst:46 ../../guide/algorithms.rst:47
 #: ../../guide/algorithms.rst:48 ../../guide/algorithms.rst:53
-#: ../../guide/algorithms.rst:77 ../../guide/algorithms.rst:78
-#: ../../guide/algorithms.rst:79 ../../guide/algorithms.rst:80
+#: ../../guide/algorithms.rst:94 ../../guide/algorithms.rst:95
+#: ../../guide/algorithms.rst:96 ../../guide/algorithms.rst:97
 #: ../../guide/jwk.rst:125
 msgid "ECKey"
 msgstr ""
@@ -201,7 +201,7 @@ msgstr ""
 msgid "EdDSA"
 msgstr ""
 
-#: ../../guide/algorithms.rst:52 ../../guide/algorithms.rst:107
+#: ../../guide/algorithms.rst:52 ../../guide/algorithms.rst:124
 #: ../../guide/jwk.rst:180
 msgid "OKPKey"
 msgstr ""
@@ -216,143 +216,151 @@ msgid ""
 "and \"Ed448\"."
 msgstr "``EdDSA`` 算法只接受具有 \"crv\" 为 \"Ed25519\" 和 \"Ed448\" 的 ``OKPKey``。"
 
-#: ../../guide/algorithms.rst:62 ../../guide/index.rst:87 ../../guide/jwe.rst:6
+#: ../../guide/algorithms.rst:59
+msgid ""
+"By default, JWS ``serialize`` and ``deserialize`` methods will ONLY allow"
+" recommended algorithms. To use non-recommended algorithms, developers "
+"MUST explicitly specify the algorithms either by the ``algorithms`` "
+"parameter, or ``registry`` parameter."
+msgstr ""
+
+#: ../../guide/algorithms.rst:79 ../../guide/index.rst:87 ../../guide/jwe.rst:6
 msgid "JSON Web Encryption"
 msgstr ""
 
-#: ../../guide/algorithms.rst:64
+#: ../../guide/algorithms.rst:81
 msgid ""
 "``joserfc.jwe`` module supports algorithms from RFC7518, and drafts of "
 "``ECDH-1PU``. You MUST specify the correct key type for each algorithm."
 msgstr "``joserfc.jwe`` 模块支持 RFC7518 中的算法，以及 ``ECDH-1PU`` 的草案。您必须为每个算法指定正确的密钥类型。"
 
-#: ../../guide/algorithms.rst:70
+#: ../../guide/algorithms.rst:87
 msgid "dir"
 msgstr ""
 
-#: ../../guide/algorithms.rst:71
+#: ../../guide/algorithms.rst:88
 msgid "A128KW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:72
+#: ../../guide/algorithms.rst:89
 msgid "A192KW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:73
+#: ../../guide/algorithms.rst:90
 msgid "A256KW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:74
+#: ../../guide/algorithms.rst:91
 msgid "RSA1_5"
 msgstr ""
 
-#: ../../guide/algorithms.rst:75
+#: ../../guide/algorithms.rst:92
 msgid "RSA-OAEP"
 msgstr ""
 
-#: ../../guide/algorithms.rst:76
+#: ../../guide/algorithms.rst:93
 msgid "RSA-OAEP-256"
 msgstr ""
 
-#: ../../guide/algorithms.rst:77 ../../guide/algorithms.rst:112
+#: ../../guide/algorithms.rst:94 ../../guide/algorithms.rst:129
 msgid "ECDH-ES"
 msgstr ""
 
-#: ../../guide/algorithms.rst:78 ../../guide/algorithms.rst:113
+#: ../../guide/algorithms.rst:95 ../../guide/algorithms.rst:130
 msgid "ECDH-ES+A128KW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:79 ../../guide/algorithms.rst:114
+#: ../../guide/algorithms.rst:96 ../../guide/algorithms.rst:131
 msgid "ECDH-ES+A192KW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:80 ../../guide/algorithms.rst:115
+#: ../../guide/algorithms.rst:97 ../../guide/algorithms.rst:132
 msgid "ECDH-ES+A256KW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:81
+#: ../../guide/algorithms.rst:98
 msgid "A128GCMKW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:82
+#: ../../guide/algorithms.rst:99
 msgid "A192GCMKW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:83
+#: ../../guide/algorithms.rst:100
 msgid "A256GCMKW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:84
+#: ../../guide/algorithms.rst:101
 msgid "PBES2-HS256+A128KW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:85
+#: ../../guide/algorithms.rst:102
 msgid "PBES2-HS384+A192KW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:86
+#: ../../guide/algorithms.rst:103
 msgid "PBES2-HS512+A256KW"
 msgstr ""
 
-#: ../../guide/algorithms.rst:89
+#: ../../guide/algorithms.rst:106
 msgid ""
 "All algorithms defined in RFC7518 for \"enc\" value are recommended, "
 "which including:"
 msgstr "RFC7518 中定义的所有用于 \"enc\" 值的算法都是推荐使用的，包括："
 
-#: ../../guide/algorithms.rst:92
+#: ../../guide/algorithms.rst:109
 msgid "``A128CBC-HS256``"
 msgstr ""
 
-#: ../../guide/algorithms.rst:93
+#: ../../guide/algorithms.rst:110
 msgid "``A192CBC-HS384``"
 msgstr ""
 
-#: ../../guide/algorithms.rst:94
+#: ../../guide/algorithms.rst:111
 msgid "``A256CBC-HS512``"
 msgstr ""
 
-#: ../../guide/algorithms.rst:95
+#: ../../guide/algorithms.rst:112
 msgid "``A128GCM``"
 msgstr ""
 
-#: ../../guide/algorithms.rst:96
+#: ../../guide/algorithms.rst:113
 msgid "``A192GCM``"
 msgstr ""
 
-#: ../../guide/algorithms.rst:97
+#: ../../guide/algorithms.rst:114
 msgid "``A256GCM``"
 msgstr ""
 
-#: ../../guide/algorithms.rst:99
+#: ../../guide/algorithms.rst:116
 msgid ""
 "A ``DEF`` algorithm for the \"zip\" (compression) header parameter is "
 "also defined in RFC7518, which is recommended."
 msgstr "RFC7518 还定义了用于 \"zip\"（压缩）头参数的 ``DEF`` 算法，该算法推荐使用。"
 
-#: ../../guide/algorithms.rst:102
+#: ../../guide/algorithms.rst:119
 msgid ""
 "There are also additional algorithms for \"alg\" and \"enc\" in draft "
 "versions. Please refer to the following sections for more information."
 msgstr "草案版本中还有针对 \"alg\" 和 \"enc\" 的额外算法。请参考以下章节获取更多信息。"
 
-#: ../../guide/algorithms.rst:109
+#: ../../guide/algorithms.rst:126
 msgid ""
 "You can use ``OKPKey`` with the \"crv\" (curve) parameter set to "
 "``X25519`` or ``X448`` for the following algorithms:"
 msgstr "对于以下算法，您可以使用 ``OKPKey`` 并将 \"crv\"（曲线）参数设置为 ``X25519`` 或 ``X448``："
 
-#: ../../guide/algorithms.rst:117
+#: ../../guide/algorithms.rst:134
 msgid ""
 "This allows you to utilize these elliptic curve algorithms with "
 "``OKPKey`` for your cryptographic operations."
 msgstr ""
 
-#: ../../guide/algorithms.rst:123
+#: ../../guide/algorithms.rst:140
 msgid "C20P and XC20P"
 msgstr "C20P 与 XC20P"
 
-#: ../../guide/algorithms.rst:125
+#: ../../guide/algorithms.rst:142
 msgid ""
 "``C20P`` and ``XC20P`` algorithms are still in drafts, they are not "
 "registered by default. To use ``C20P`` and ``XC20P``, developers have to "
@@ -361,7 +369,7 @@ msgstr ""
 "``C20P`` 和 ``XC20P`` 算法仍处于草案阶段，默认状态下他们未注册到 ``JWERegistry``。要使用 ``C20P`` 和"
 " ``XC20P``，开发人员必须安装 ``PyCryptodome`` 模块。"
 
-#: ../../guide/algorithms.rst:132
+#: ../../guide/algorithms.rst:149
 msgid ""
 "This is caused by ``cryptography`` package does only support \"ChaCha20\""
 " cipher, not **XChaCha20**, while ``pycryptodome`` supports both "
@@ -370,21 +378,21 @@ msgstr ""
 "这是由于 ``cryptography`` 库只支持 \"ChaCha20\" 密码算法，不支持 **XChaCha20**，而 "
 "``pycryptodome`` 同时支持 \"ChaCha20\" 和 \"XChaCha20\" 密码算法。"
 
-#: ../../guide/algorithms.rst:136
+#: ../../guide/algorithms.rst:153
 msgid "Register ciphers"
 msgstr "注册密码算法"
 
-#: ../../guide/algorithms.rst:138
+#: ../../guide/algorithms.rst:155
 msgid ""
 "The default :ref:`registry` doesn't contain draft ciphers, developers "
 "MUST register ``C20P`` and ``XC20P`` at first:"
 msgstr "默认的 :ref:`registry` 不包含草案算法，开发人员必须先注册 ``C20P`` 和 ``XC20P``："
 
-#: ../../guide/algorithms.rst:148
+#: ../../guide/algorithms.rst:165
 msgid "Use custom ``registry``"
 msgstr "自定义注册表 ``registry``"
 
-#: ../../guide/algorithms.rst:153
+#: ../../guide/algorithms.rst:170
 msgid ""
 "Use a custom ``registry`` in :meth:`encrypt_compact`, "
 ":meth:`decrypt_compact`, :meth:`encrypt_json`, and :meth:`decrypt_json`."
@@ -392,11 +400,11 @@ msgstr ""
 "在 :meth:`encrypt_compact`、:meth:`decrypt_compact`、:meth:`encrypt_json` 和 "
 ":meth:`decrypt_json` 中使用自定义 ``registry``。"
 
-#: ../../guide/algorithms.rst:178
+#: ../../guide/algorithms.rst:195
 msgid "ECDH-1PU algorithms"
 msgstr "ECDH-1PU 相关算法"
 
-#: ../../guide/algorithms.rst:180
+#: ../../guide/algorithms.rst:197
 msgid ""
 "Key Agreement with Elliptic Curve Diffie-Hellman One-Pass Unified Model "
 "(ECDH-1PU) are still in drafts, they are not registered by default. To "
@@ -406,13 +414,13 @@ msgstr ""
 "椭圆曲线迪菲-赫尔曼一次通用模型（ECDH-1PU）密钥协商仍然处于草案阶段，默认情况下未注册。要使用与 ``ECDH-1PU`` "
 "相关的算法，开发人员必须手动注册它们："
 
-#: ../../guide/algorithms.rst:190
+#: ../../guide/algorithms.rst:207
 msgid ""
 "Then use a custom ``registry`` with the required ``ECDH-1PU`` algorithms."
 " For instance:"
 msgstr "然后使用带有所需的 ``ECDH-1PU`` 算法的自定义 ``registry``。例如："
 
-#: ../../guide/algorithms.rst:213
+#: ../../guide/algorithms.rst:230
 msgid ""
 "The ``ECDH-1PU`` algorithms require a **sender key**, which MUST be a "
 "private key when calling :meth:`encrypt_compact` and :meth:`encrypt_json`"
@@ -421,7 +429,7 @@ msgstr ""
 "``ECDH-1PU`` 算法需要一个 **发送方密钥**，在调用 :meth:`encrypt_compact` 和 "
 ":meth:`encrypt_json` 方法时，该密钥必须是私钥。"
 
-#: ../../guide/algorithms.rst:216
+#: ../../guide/algorithms.rst:233
 msgid ""
 "The ``sender_key`` can be a :class:`~joserfc.jwk.KeySet`, and JWE will "
 "find the correct key according to ``skid`` header value."
@@ -650,7 +658,7 @@ msgstr ""
 
 #: ../../guide/jwe.rst:116
 msgid ""
-"``jwe.JSONEncryption`` is seperated to ``GeneralJSONEncryption`` and "
+"``jwe.JSONEncryption`` is separated to ``GeneralJSONEncryption`` and "
 "``FlattenedJSONEncryption``."
 msgstr ""
 
@@ -1140,8 +1148,8 @@ msgstr ""
 msgid ""
 "There are two types of JSON JWS serializations, \"general\" and "
 "\"flattened\". The above example is a General JSON Serialization. A "
-"Flattened JSON Serialization contains only one member. Compair the bellow"
-" examples:"
+"Flattened JSON Serialization contains only one member. Compare the below "
+"examples:"
 msgstr ""
 
 #: ../../guide/jws.rst:182
@@ -1168,7 +1176,7 @@ msgstr ""
 
 #: ../../guide/jws.rst:228
 msgid ""
-"``jws.JSONSignature`` is seperated to ``GeneralJSONSignature`` and "
+"``jws.JSONSignature`` is separated to ``GeneralJSONSignature`` and "
 "``FlattenedJSONSignature``."
 msgstr ""
 
@@ -1247,10 +1255,16 @@ msgid "ECDSA using secp256k1 curve and SHA-256"
 msgstr ""
 
 #: ../../guide/jws.rst:265
-msgid "Algorithm not allowed"
+msgid "UnsupportedAlgorithmError"
 msgstr ""
 
-#: ../../guide/jws.rst:267
+#: ../../guide/jws.rst:269
+msgid ""
+"From version 1.1.0, an ``UnsupportedAlgorithmError`` will be raised "
+"instead of a ``ValueError``."
+msgstr ""
+
+#: ../../guide/jws.rst:272
 msgid ""
 "The serialization and deserialization methods on ``joserfc.jws`` module "
 "accept an ``algorithms`` parameter for specifying the allowed algorithms."
@@ -1259,60 +1273,60 @@ msgid ""
 "algorithms, you may encounter the below error."
 msgstr ""
 
-#: ../../guide/jws.rst:287
+#: ../../guide/jws.rst:293
 msgid ""
 "``joserfc`` does support ``HS384``, but this algorithm is not recommended"
-" by specifications, developers MUST explict specify the supported "
+" by specifications, developers MUST explicitly specify the supported "
 "algorithms either by the ``algorithms`` parameter, or ``registry`` "
 "parameter."
 msgstr ""
 
-#: ../../guide/jws.rst:299
+#: ../../guide/jws.rst:305
 msgid ""
 "Developers can also apply the ``registry`` parameter to resolve this "
 "issue. Here is an example of using :ref:`registry`."
 msgstr ""
 
-#: ../../guide/jws.rst:314
+#: ../../guide/jws.rst:320
 msgid "Unencoded Payload Option"
 msgstr ""
 
-#: ../../guide/jws.rst:316
+#: ../../guide/jws.rst:322
 msgid ""
 "The unencoded payload option, defined in RFC7797, allows the payload of a"
 " JWS (JSON Web Signature) to remain unencoded, without using base64 "
 "encoding."
 msgstr ""
 
-#: ../../guide/jws.rst:319
+#: ../../guide/jws.rst:325
 msgid ""
 "To enable this option, you need to set the ``b64`` header parameter to "
 "``false`` in the JWS header."
 msgstr ""
 
-#: ../../guide/jws.rst:322
+#: ../../guide/jws.rst:328
 msgid ""
 "To utilize the unencoded payload option in joserfc, you must import the "
 "serialize and deserialize methods from ``joserfc.rfc7797``."
 msgstr ""
 
-#: ../../guide/jws.rst:325
+#: ../../guide/jws.rst:331
 msgid "Here are examples demonstrating the usage of the ``b64`` option:"
 msgstr ""
 
-#: ../../guide/jws.rst:340
+#: ../../guide/jws.rst:346
 msgid ""
 "The ``crit`` MUST be present with ``\"b64\"`` in its value set when "
 "``b64`` is in the header."
 msgstr ""
 
-#: ../../guide/jws.rst:343
+#: ../../guide/jws.rst:349
 msgid ""
 "Since the payload is not base64 encoded, if the payload contains non "
 "urlsafe characters, the compact serialization will detach the payload:"
 msgstr ""
 
-#: ../../guide/jws.rst:359
+#: ../../guide/jws.rst:365
 msgid ""
 "There are also methods for JSON serialization: ``serialize_json`` and "
 "``deserialize_json``."
@@ -1584,7 +1598,7 @@ msgstr ""
 msgid ""
 "The :meth:`encode` and :meth:`decode` accept an ``algorithms`` parameter "
 "for specifying the allowed algorithms. By default, it only allows your to"
-" use recommended algorithms."
+" use **recommended** algorithms."
 msgstr ""
 
 #: ../../guide/jwt.rst:296
@@ -1601,6 +1615,37 @@ msgstr ""
 msgid ""
 "If not specifying the ``algorithms`` parameter, the ``encode`` method "
 "will raise an error."
+msgstr ""
+
+#: ../../guide/jwt.rst:316
+#, fuzzy
+msgid "JSON Encoder and Decoder"
+msgstr "JWT 的编码与解码"
+
+#: ../../guide/jwt.rst:320
+msgid ""
+"The parameters ``encoder_cls`` for ``jwt.encode`` and ``decoder_cls`` for"
+" ``jwt.decode`` were introduced in version 1.1.0."
+msgstr ""
+
+#: ../../guide/jwt.rst:323
+msgid ""
+"When using ``jwt.encode``` to encode claims that contain data types that "
+"``json`` module does not natively support, such as ``UUID`` and "
+"``datetime``, an error will be raised."
+msgstr ""
+
+#: ../../guide/jwt.rst:356
+msgid ""
+"To resolve this issue, you can pass a custom ``JSONEncoder`` using the "
+"``encoder_cls`` parameter."
+msgstr ""
+
+#: ../../guide/jwt.rst:374
+msgid ""
+"Additionally, ``jwt.decode`` accepts a ``decoder_cls`` parameter. If you "
+"need to convert the decoded claims into the appropriate data types, you "
+"can provide a custom decoder class."
 msgstr ""
 
 #: ../../guide/registry.rst:6
@@ -1738,12 +1783,3 @@ msgid ""
 "Depending on the algorithm of the JWT, you need to decide whether to use "
 "``JWSRegistry`` or ``JWERegistry``."
 msgstr ""
-
-#~ msgid ""
-#~ "You can define claims requests "
-#~ ":class:`JWTClaimsRegistry` for validating the "
-#~ "decoded claims. The ``JWTClaimsRegistry`` "
-#~ "accepts each claim as an `Individual "
-#~ "Claims Requests <ClaimsOption>`_ JSON object."
-#~ msgstr ""
-

--- a/src/joserfc/errors.py
+++ b/src/joserfc/errors.py
@@ -18,7 +18,15 @@ class JoseError(Exception):
 
 
 class DecodeError(JoseError):
+    """This error is designed for JWS/JWE. It is raised when deserialization
+    and decryption fails.
+    """
+
     error = "decode_error"
+
+
+class MissingKeyError(JoseError):
+    error = "missing_key"
 
 
 class UnsupportedKeyUseError(JoseError):
@@ -72,10 +80,6 @@ class UnsupportedAlgorithmError(JoseError):
     error = "unsupported_algorithm"
 
 
-class MissingKeyError(JoseError):
-    error = "missing_key"
-
-
 class InvalidHeaderValueError(JoseError):
     error = "invalid_header_value"
 
@@ -105,6 +109,9 @@ class MissingCritHeaderError(JoseError):
 
 
 class MissingEncryptionError(JoseError):
+    """This error is designed for JWE. It is raised when the 'enc' value
+    in header is missing."""
+
     error = "missing_encryption"
     description = "Missing 'enc' value in header"
 
@@ -142,6 +149,9 @@ class InvalidCEKLengthError(JoseError):
 
 
 class InvalidClaimError(JoseError):
+    """This error is designed for JWT. It raised when the claim contains
+    invalid values or types."""
+
     error = "invalid_claim"
 
     def __init__(self, claim: str):
@@ -150,6 +160,9 @@ class InvalidClaimError(JoseError):
 
 
 class MissingClaimError(JoseError):
+    """This error is designed for JWT. It raised when the required
+    claims are missing."""
+
     error = "missing_claim"
 
     def __init__(self, claim: str):
@@ -158,6 +171,9 @@ class MissingClaimError(JoseError):
 
 
 class InsecureClaimError(JoseError):
+    """This error is designed for JWT. It raised when the claim
+    contains sensitive information."""
+
     error = "insecure_claim"
 
     def __init__(self, claim: str):
@@ -166,14 +182,21 @@ class InsecureClaimError(JoseError):
 
 
 class ExpiredTokenError(JoseError):
+    """This error is designed for JWT. It raised when the token is expired."""
+
     error = "expired_token"
     description = "The token is expired"
 
 
 class InvalidTokenError(JoseError):
+    """This error is designed for JWT. It raised when the token is not valid yet."""
+
     error = "invalid_token"
     description = "The token is not valid yet"
 
 
 class InvalidPayloadError(JoseError):
+    """This error is designed for JWT. It raised when the payload is
+    not a valid JSON object."""
+
     error = "invalid_payload"

--- a/src/joserfc/errors.py
+++ b/src/joserfc/errors.py
@@ -76,6 +76,10 @@ class MissingKeyError(JoseError):
     error = "missing_key"
 
 
+class InvalidHeaderValueError(JoseError):
+    error = "invalid_header_value"
+
+
 class UnsupportedHeaderError(JoseError):
     error = "unsupported_header"
 

--- a/src/joserfc/registry.py
+++ b/src/joserfc/registry.py
@@ -4,6 +4,7 @@ from .errors import (
     MissingHeaderError,
     MissingCritHeaderError,
     UnsupportedHeaderError,
+    InvalidHeaderValueError,
 )
 
 Header = Dict[str, Any]
@@ -190,7 +191,7 @@ def validate_registry_header(registry: HeaderRegistryDict, header: Header, check
             try:
                 reg.validate(header[key])
             except ValueError as error:
-                raise ValueError(f"'{key}' in header {error}")
+                raise InvalidHeaderValueError(f"'{key}' in header {error}")
 
 
 def check_crit_header(header: Header) -> None:

--- a/tests/jwe/test_compact.py
+++ b/tests/jwe/test_compact.py
@@ -8,6 +8,7 @@ from joserfc.errors import (
     MissingEncryptionError,
     DecodeError,
     ExceededSizeError,
+    InvalidHeaderValueError,
 )
 from joserfc.util import json_b64encode
 from tests.base import load_key
@@ -166,7 +167,7 @@ class TestJWECompact(TestCase):
         # invalid type
         protected["p2c"] = "1024"
         self.assertRaises(
-            ValueError,
+            InvalidHeaderValueError,
             encrypt_compact,
             protected,
             b"i",

--- a/tests/jws/test_errors.py
+++ b/tests/jws/test_errors.py
@@ -27,6 +27,10 @@ class TestJWSErrors(TestCase):
     def test_without_key(self):
         self.assertRaises(MissingKeyError, jws.serialize_compact, {"alg": "HS256"}, "i", None)
 
+        header = {"alg": "HS256"}
+        text = jws.serialize_compact(header, "i", self.key)
+        self.assertRaises(MissingKeyError, jws.deserialize_compact, text, None)
+
     def test_none_alg(self):
         header = {"alg": "none"}
         text = jws.serialize_compact(header, "i", None, algorithms=["none"])

--- a/tests/jws/test_errors.py
+++ b/tests/jws/test_errors.py
@@ -12,6 +12,7 @@ from joserfc.errors import (
     MissingHeaderError,
     MissingCritHeaderError,
     UnsupportedHeaderError,
+    InvalidHeaderValueError,
 )
 from joserfc.util import urlsafe_b64encode
 from tests.base import load_key
@@ -32,14 +33,14 @@ class TestJWSErrors(TestCase):
         obj = jws.deserialize_compact(text, None, algorithms=["none"])
         self.assertEqual(obj.payload, b"i")
         # none alg has no signature
-        text += 'aQ'
+        text += "aQ"
         self.assertRaises(BadSignatureError, jws.deserialize_compact, text, None, algorithms=["none"])
 
     def test_header_invalid_type(self):
         # kid should be a string
         header = {"alg": "HS256", "kid": 123}
         self.assertRaises(
-            ValueError,
+            InvalidHeaderValueError,
             jws.serialize_compact,
             header,
             "i",
@@ -49,7 +50,7 @@ class TestJWSErrors(TestCase):
         # jwk should be a dict
         header = {"alg": "HS256", "jwk": "dict"}
         self.assertRaises(
-            ValueError,
+            InvalidHeaderValueError,
             jws.serialize_compact,
             header,
             "i",
@@ -59,7 +60,7 @@ class TestJWSErrors(TestCase):
         # jku should be a URL
         header = {"alg": "HS256", "jku": "url"}
         self.assertRaises(
-            ValueError,
+            InvalidHeaderValueError,
             jws.serialize_compact,
             header,
             "i",
@@ -69,7 +70,7 @@ class TestJWSErrors(TestCase):
         # x5c should be a chain of string
         header = {"alg": "HS256", "x5c": "url"}
         self.assertRaises(
-            ValueError,
+            InvalidHeaderValueError,
             jws.serialize_compact,
             header,
             "i",
@@ -77,7 +78,7 @@ class TestJWSErrors(TestCase):
         )
         header = {"alg": "HS256", "x5c": [1, 2]}
         self.assertRaises(
-            ValueError,
+            InvalidHeaderValueError,
             jws.serialize_compact,
             header,
             "i",

--- a/tests/jws/test_rfc7797.py
+++ b/tests/jws/test_rfc7797.py
@@ -10,6 +10,7 @@ from joserfc.errors import (
     DecodeError,
     MissingAlgorithmError,
     BadSignatureError,
+    InvalidHeaderValueError,
 )
 from joserfc.util import to_bytes
 from joserfc import jws
@@ -43,7 +44,7 @@ class TestRFC7797(TestFixture):
 
     def test_invalid_b64_value(self):
         protected = {"alg": "HS256", "b64": "true", "crit": ["b64"]}
-        self.assertRaises(ValueError, serialize_compact, protected, "i", default_key)
+        self.assertRaises(InvalidHeaderValueError, serialize_compact, protected, "i", default_key)
 
     def test_compact_invalid_value_length(self):
         self.assertRaises(ValueError, deserialize_compact, b"a.b.c.d.e", default_key)


### PR DESCRIPTION
Use `InvalidHeaderValueError` to replace `ValueError`.