### PR TITLE
Prevent from Base64 Malleability

### DIFF
--- a/tests/jws/test_compact.py
+++ b/tests/jws/test_compact.py
@@ -73,3 +73,12 @@ class TestCompact(TestCase):
 
         registry = JWSRegistry(strict_check_header=False)
         serialize_compact(header, b"hi", key, registry=registry)
+
+    def test_non_canonical_signature_encoding(self):
+        text = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWRtaW4ifQ.VI29GgHzuh2xfF0bkRYvZIsSuQnbTXSIvuRyt7RDrwo"[:-1] + "p"
+        self.assertRaises(
+            DecodeError,
+            jws.deserialize_compact,
+            text,
+            self.key # no matter
+        )

--- a/tests/jws/test_compact.py
+++ b/tests/jws/test_compact.py
@@ -78,7 +78,7 @@ class TestCompact(TestCase):
         text = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWRtaW4ifQ.VI29GgHzuh2xfF0bkRYvZIsSuQnbTXSIvuRyt7RDrwo"[:-1] + "p"
         self.assertRaises(
             DecodeError,
-            jws.deserialize_compact,
+            deserialize_compact,
             text,
-            self.key # no matter
+            OctKey.import_key("secret")
         )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 import binascii
 from unittest import TestCase
 from joserfc import util
-
+from joserfc import errors
 
 class TestUtil(TestCase):
     def test_to_bytes(self):
@@ -23,3 +23,7 @@ class TestUtil(TestCase):
     def test_urlsafe_b64decode(self):
         self.assertEqual(util.urlsafe_b64decode(b"_foo123-"), b"\xfd\xfa(\xd7m\xfe")
         self.assertRaises(binascii.Error, util.urlsafe_b64decode, b"+foo123/")
+        for c in "RSTUVWXYZabdef": # A -> QQ==
+            self.assertRaises(errors.DecodeError, util.urlsafe_b64decode, b"Q" + c.encode())
+        for c in "FGH": # AAAAAAAAAAAAAA -> QUFBQUFBQUFBQUFBQUE=
+            self.assertRaises(errors.DecodeError, util.urlsafe_b64decode, b"QUFBQUFBQUFBQUFBQU" + c.encode())


### PR DESCRIPTION
Hi,

The Pentesterlab API JWT revocation exercise is based on the fact that base64 decoding library accept non canonical form.

> The revocation is based on a cache that stores the full JWT token. If an exact match is found in the cache, the JWT is revoked and the request is rejected. However, the match is strictly an exact match and does not account for the malleability of Base64 encoding. 

The RFC 4648 talk about this security issue in 3.5 and 12.

@rb-x demonstrates it in this issue (Multiple valid JWT Signatures for HMAC Algorithms).

I used this fact to build base64 steganography tools and in fact it is very easy to detect non canonical form just by checking the last character of the string:
```
b64_print_regular_characters.sh
...
* List of REGULAR characters with FOUR padding bits (string ends with ==)
A Q g w [AQgw]
...
* List of REGULAR characters with TWO padding bits (string ends with =)
A E I M Q U Y c g k o s w 0 4 8 [AEIMQUYcgkosw048]
...
```
So, I propose to implement this check in the `urlsafe_b64decode(s: bytes) -> bytes` function to raise an `DecodeError` to **protect JOSE from any tampering of base64 encoding :no_entry: :pirate_flag:**.

* https://pentesterlab.com/exercises/api-jwt-revocation
* https://datatracker.ietf.org/doc/html/rfc4648#section-3.5
* https://datatracker.ietf.org/doc/html/rfc4648#section-12
* https://github.com/mpdavis/python-jose/issues/365
* https://github.com/FrancoisCapon/Base64SteganographyTools/blob/main/tools/b64_print_regular_characters.sh
* https://github.com/FrancoisCapon/Base64SteganographyTools