### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/authlib/joserfc/security/code-scanning/4](https://github.com/authlib/joserfc/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the `GITHUB_TOKEN` to the minimum required permissions. Since the workflow primarily involves reading repository contents (e.g., checking out code, installing dependencies, and running tests), we will set `contents: read`. This ensures the workflow has only the permissions it needs to function correctly.

The `permissions` block will be added at the top level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
