### PR TITLE
Warn about weak key size

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,10 @@ Changelog
 **Unreleased**
 
 - Show security warnings for ``none`` and ``RSA1_5`` algorithms.
+- Show security warnings for ``OctKey.generate_key`` and ``RSAKey.generate_key``
+  when key size is too short, per `NIST SP 800-131A`_.
+
+.. _`NIST SP 800-131A`: https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final
 
 **Breaking changes**:
 
@@ -52,7 +56,7 @@ Changelog
 **Released on Feb 28, 2025**
 
 - Use secrets module to generate random bytes.
-- Use warnings for possible unsafe ``OctKey``` instead of raising error, via :issue:`32`.
+- Use warnings for possible unsafe ``OctKey`` instead of raising error, via :issue:`32`.
 
 1.0.3
 -----

--- a/docs/guide/errors.rst
+++ b/docs/guide/errors.rst
@@ -1,0 +1,54 @@
+Errors & Warnings
+=================
+
+Here are some common errors and warnings, and how to handle them.
+
+SecurityWarning
+---------------
+
+You may encounter a ``SecurityWarning`` when using potentially
+unsafe algorithms or generating insecure keys. These warnings
+do not interrupt the execution of your application — they are
+simply printed to standard output (e.g., your terminal).
+
+If you prefer to suppress these warnings, you can use Python’s
+built-in ``warnings`` module:
+
+.. code-block:: python
+
+    import warnings
+    from joserfc.errors import SecurityWarning
+
+    warnings.simplefilter('ignore', SecurityWarning)
+
+With this configuration, ``SecurityWarning`` messages will no
+longer appear. Be cautious when suppressing these warnings, as
+they are meant to alert you to potentially insecure practices.
+
+UnsupportedAlgorithmError
+-------------------------
+
+By default, **ONLY recommended** :ref:`jwa` are allowed. With non recommended
+algorithms, you may encounter the ``UnsupportedAlgorithmError``` error.
+
+.. code-block:: python
+
+    >>> from joserfc import jws
+    >>> from joserfc.jwk import OctKey
+    >>> key = OctKey.generate_key()
+    >>> jws.serialize_compact({"alg": "HS384"}, b"payload", key)
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File ".../joserfc/jws.py", line 112, in serialize_compact
+        alg: JWSAlgModel = registry.get_alg(protected["alg"])
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      File ".../joserfc/_rfc7515/registry.py", line 60, in get_alg
+        raise UnsupportedAlgorithmError(f'Algorithm of "{name}" is not recommended')
+    joserfc.errors.UnsupportedAlgorithmError: unsupported_algorithm: Algorithm of "HS384" is not recommended
+
+Because "HS384" is not a recommended algorithm, it is not allowed by default. You
+SHOULD enable it manually by passing an ``algorithms`` parameter:
+
+.. code-block:: python
+
+    >>> jws.serialize_compact({"alg": "HS384"}, b"payload", key, algorithms=["HS384"])

--- a/docs/guide/jws.rst
+++ b/docs/guide/jws.rst
@@ -279,14 +279,14 @@ the below error.
 
     >>> from joserfc import jws
     >>> from joserfc.jwk import OctKey
-    >>> key = OctKey.import_key("secret")
+    >>> key = OctKey.generate_key()
     >>> jws.serialize_compact({"alg": "HS384"}, b"payload", key)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
       File ".../joserfc/jws.py", line 112, in serialize_compact
         alg: JWSAlgModel = registry.get_alg(protected["alg"])
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      File ".../joserfc/rfc7515/registry.py", line 60, in get_alg
+      File ".../joserfc/_rfc7515/registry.py", line 60, in get_alg
         raise UnsupportedAlgorithmError(f'Algorithm of "{name}" is not recommended')
     joserfc.errors.UnsupportedAlgorithmError: unsupported_algorithm: Algorithm of "HS384" is not recommended
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,6 +78,7 @@ Explore the following sections to discover more about ``joserfc`` and its featur
    guide/index
    guide/algorithms
    guide/registry
+   guide/errors
    migrations/index
 
 .. toctree::

--- a/docs/locales/zh/LC_MESSAGES/changelog.po
+++ b/docs/locales/zh/LC_MESSAGES/changelog.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  joserfc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-30 14:51+0900\n"
+"POT-Creation-Date: 2025-07-03 11:52+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh\n"
@@ -39,11 +39,17 @@ msgstr ""
 msgid "Show security warnings for ``none`` and ``RSA1_5`` algorithms."
 msgstr ""
 
-#: ../../changelog.rst:22 ../../changelog.rst:41 ../../changelog.rst:154
+#: ../../changelog.rst:21
+msgid ""
+"Show security warnings for ``OctKey.generate_key`` and "
+"``RSAKey.generate_key`` when key size is too short."
+msgstr ""
+
+#: ../../changelog.rst:23 ../../changelog.rst:42 ../../changelog.rst:155
 msgid "**Breaking changes**:"
 msgstr ""
 
-#: ../../changelog.rst:24
+#: ../../changelog.rst:25
 msgid ""
 "Enable \"RFC7797\" by default, use the ``joserfc.jws`` module directly. -"
 " Use ``joserfc.jws.serialize_compact`` instead of "
@@ -55,398 +61,399 @@ msgid ""
 " instead of ``joserfc.rfc7797.deserialize_json``"
 msgstr ""
 
-#: ../../changelog.rst:29
+#: ../../changelog.rst:30
 msgid "Convert ``joserfc.rfcXXXX`` to private modules ``joserfc._rfcXXXX``."
 msgstr ""
 
-#: ../../changelog.rst:32
+#: ../../changelog.rst:33
 msgid "1.1.0"
 msgstr ""
 
-#: ../../changelog.rst:34
+#: ../../changelog.rst:35
 msgid "**Released on May 24, 2025**"
 msgstr ""
 
-#: ../../changelog.rst:36
+#: ../../changelog.rst:37
 msgid "Use \"import as\" to prioritize the modules for editors."
 msgstr ""
 
-#: ../../changelog.rst:37
+#: ../../changelog.rst:38
 msgid ""
 "Added parameter ``encoder_cls`` for ``jwt.encode`` and ``decoder_cls`` "
 "for ``jwt.decode``."
 msgstr ""
 
-#: ../../changelog.rst:38
+#: ../../changelog.rst:39
 msgid "Added ``none`` algorithm for JWS."
 msgstr ""
 
-#: ../../changelog.rst:39
+#: ../../changelog.rst:40
 msgid "Added ``jwk.import_key`` and ``jwk.generate_key`` aliases."
 msgstr ""
 
-#: ../../changelog.rst:43
+#: ../../changelog.rst:44
 msgid "Use ``ECKey.binding.register_curve`` to register new supported curves."
 msgstr ""
 
-#: ../../changelog.rst:44
+#: ../../changelog.rst:45
 msgid ""
 "Use ``UnsupportedAlgorithmError`` instead of ``ValueError`` in JWS/JWE "
 "registry."
 msgstr ""
 
-#: ../../changelog.rst:45
+#: ../../changelog.rst:46
 msgid "Use ``MissingKeyTypeError`` and ``InvalidKeyIdError`` for errors in JWK."
 msgstr ""
 
-#: ../../changelog.rst:46
+#: ../../changelog.rst:47
 msgid ""
 "Use ``UnsupportedHeaderError``, ``MissingHeaderError``, and "
 "``MissingCritHeaderError`` for header validation."
 msgstr ""
 
-#: ../../changelog.rst:47
+#: ../../changelog.rst:48
 msgid "Respect RFC6749 character set in error descriptions."
 msgstr ""
 
-#: ../../changelog.rst:50
+#: ../../changelog.rst:51
 msgid "1.0.4"
 msgstr ""
 
-#: ../../changelog.rst:52
+#: ../../changelog.rst:53
 msgid "**Released on Feb 28, 2025**"
 msgstr ""
 
-#: ../../changelog.rst:54
+#: ../../changelog.rst:55
 msgid "Use secrets module to generate random bytes."
 msgstr ""
 
-#: ../../changelog.rst:55
+#: ../../changelog.rst:56
 msgid ""
 "Use warnings for possible unsafe ``OctKey``` instead of raising error, "
 "via :issue:`32`."
 msgstr ""
 
-#: ../../changelog.rst:58
+#: ../../changelog.rst:59
 msgid "1.0.3"
 msgstr ""
 
-#: ../../changelog.rst:60
+#: ../../changelog.rst:61
 msgid "**Released on Feb 6, 2025**"
 msgstr ""
 
-#: ../../changelog.rst:62
+#: ../../changelog.rst:63
 msgid "Allow using sha256, sha384, sha512 hash functions in thumbprint (RFC7638)."
 msgstr ""
 
-#: ../../changelog.rst:65
+#: ../../changelog.rst:66
 msgid "1.0.2"
 msgstr ""
 
-#: ../../changelog.rst:67
+#: ../../changelog.rst:68
 msgid "**Released on Jan 20, 2025**"
 msgstr ""
 
-#: ../../changelog.rst:69
+#: ../../changelog.rst:70
 msgid "Support import key from a certificate pem file."
 msgstr ""
 
-#: ../../changelog.rst:72
+#: ../../changelog.rst:73
 msgid "1.0.1"
 msgstr ""
 
-#: ../../changelog.rst:74
+#: ../../changelog.rst:75
 msgid "**Released on December 3, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:76
+#: ../../changelog.rst:77
 msgid "Throw an error on non-valid base64 strings."
 msgstr ""
 
-#: ../../changelog.rst:79
+#: ../../changelog.rst:80
 msgid "1.0.0"
 msgstr ""
 
-#: ../../changelog.rst:81
+#: ../../changelog.rst:82
 msgid "**Released on July 14, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:83
+#: ../../changelog.rst:84
 msgid "Fix type hints for strict mode."
 msgstr ""
 
-#: ../../changelog.rst:86
+#: ../../changelog.rst:87
 msgid "0.12.0"
 msgstr ""
 
-#: ../../changelog.rst:88
+#: ../../changelog.rst:89
 msgid "**Released on June 15, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:90
+#: ../../changelog.rst:91
 msgid "Limit DEF decompress size to 250k bytes."
 msgstr ""
 
-#: ../../changelog.rst:91
+#: ../../changelog.rst:92
 msgid "Fix claims validation, via :issue:`23`."
 msgstr ""
 
-#: ../../changelog.rst:94
+#: ../../changelog.rst:95
 msgid "0.11.1"
 msgstr ""
 
-#: ../../changelog.rst:96 ../../changelog.rst:103
+#: ../../changelog.rst:97 ../../changelog.rst:104
 msgid "**Released on June 4, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:98
+#: ../../changelog.rst:99
 msgid "Remove validating ``typ`` header with ``jwt.decode`` method."
 msgstr ""
 
-#: ../../changelog.rst:101
+#: ../../changelog.rst:102
 msgid "0.11.0"
 msgstr ""
 
-#: ../../changelog.rst:105
+#: ../../changelog.rst:106
 msgid "``jwe.decrypt_json`` allows to verify only one recipient."
 msgstr ""
 
-#: ../../changelog.rst:106
+#: ../../changelog.rst:107
 msgid "Prevent ``OctKey`` to import ``ssh-dss``."
 msgstr ""
 
-#: ../../changelog.rst:107
+#: ../../changelog.rst:108
 msgid "Deprecate use of string and bytes as key."
 msgstr ""
 
-#: ../../changelog.rst:110
+#: ../../changelog.rst:111
 msgid "0.10.0"
 msgstr ""
 
-#: ../../changelog.rst:112
+#: ../../changelog.rst:113
 msgid "**Released on May 13, 2024**"
 msgstr ""
 
-#: ../../changelog.rst:114
+#: ../../changelog.rst:115
 msgid "Change ``jwt.encode`` and ``jwt.decode`` to use JWS by default."
 msgstr ""
 
-#: ../../changelog.rst:117
+#: ../../changelog.rst:118
 msgid "0.9.0"
 msgstr ""
 
-#: ../../changelog.rst:119
+#: ../../changelog.rst:120
 msgid "**Released on November 16, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:121
+#: ../../changelog.rst:122
 msgid "Use ``os.urandom`` for ``OctKey.generate_key``."
 msgstr ""
 
-#: ../../changelog.rst:122
+#: ../../changelog.rst:123
 msgid "Add ``allow_blank`` for ``JWTClaimsRegistry``."
 msgstr ""
 
-#: ../../changelog.rst:123
+#: ../../changelog.rst:124
 msgid "Improve callable key for :meth:`~jwk.guess_key`."
 msgstr ""
 
-#: ../../changelog.rst:126
+#: ../../changelog.rst:127
 msgid "0.8.0"
 msgstr ""
 
-#: ../../changelog.rst:128
+#: ../../changelog.rst:129
 msgid "**Released on September 06, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:130
+#: ../../changelog.rst:131
 msgid "Add :ref:`ensure_kid` method on key models."
 msgstr ""
 
-#: ../../changelog.rst:131
+#: ../../changelog.rst:132
 msgid "Add ``auto_kid`` parameter on key model ``.generate_key`` method."
 msgstr ""
 
-#: ../../changelog.rst:132 ../../changelog.rst:142
+#: ../../changelog.rst:133 ../../changelog.rst:143
 msgid "Improvements on type hints"
 msgstr ""
 
-#: ../../changelog.rst:135
+#: ../../changelog.rst:136
 msgid "0.7.0"
 msgstr ""
 
-#: ../../changelog.rst:137
+#: ../../changelog.rst:138
 msgid "**Released on August 14, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:139
+#: ../../changelog.rst:140
 msgid "Add \"iat\" claims validation in JWT."
 msgstr ""
 
-#: ../../changelog.rst:140
+#: ../../changelog.rst:141
 msgid "Add ``__bool__`` magic method on :class:`jwk.KeySet`."
 msgstr ""
 
-#: ../../changelog.rst:141
+#: ../../changelog.rst:142
 msgid ""
 "Raise ``InvalidExchangeKeyError`` for ``exchange_derive_key`` on Curve "
 "key."
 msgstr ""
 
-#: ../../changelog.rst:145
+#: ../../changelog.rst:146
 msgid "0.6.0"
 msgstr ""
 
-#: ../../changelog.rst:147
+#: ../../changelog.rst:148
 msgid "**Released on July 20, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:149
+#: ../../changelog.rst:150
 msgid "Huge improvements on type hints, via :user:`Viicos`."
 msgstr ""
 
-#: ../../changelog.rst:150
+#: ../../changelog.rst:151
 msgid "Do not mutate the header when ``jwt.encode``, via :issue:`6`."
 msgstr ""
 
-#: ../../changelog.rst:151
+#: ../../changelog.rst:152
 msgid "Register algorithms with their matched key types on key set."
 msgstr ""
 
-#: ../../changelog.rst:152
+#: ../../changelog.rst:153
 msgid "Improve error handling, raise proper errors."
 msgstr ""
 
-#: ../../changelog.rst:156
+#: ../../changelog.rst:157
 msgid ""
 "``jws.JSONSignature`` is replaced by :class:`jws.GeneralJSONSignature` "
 "and :class:`jws.FlattenedJSONSignature`."
 msgstr ""
 
-#: ../../changelog.rst:158
+#: ../../changelog.rst:159
 msgid ""
 "``jwe.JSONEncryption`` is replaced by :class:`jwe.GeneralJSONEncryption` "
 "and :class:`jwe.FlattenedJSONEncryption`."
 msgstr ""
 
-#: ../../changelog.rst:162
+#: ../../changelog.rst:163
 msgid "0.5.0"
 msgstr ""
 
-#: ../../changelog.rst:164
+#: ../../changelog.rst:165
 msgid "**Released on July 12, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:166
+#: ../../changelog.rst:167
 msgid "Add RFC7797 JSON Web Signature (JWS) Unencoded Payload Option"
 msgstr ""
 
-#: ../../changelog.rst:167
+#: ../../changelog.rst:168
 msgid "Fix ``decrypt_json`` when there is no ``encrypted_key``"
 msgstr ""
 
-#: ../../changelog.rst:168
+#: ../../changelog.rst:169
 msgid "Rename JWE CompleteJSONSerialization to GeneralJSONSerialization"
 msgstr ""
 
-#: ../../changelog.rst:169
+#: ../../changelog.rst:170
 msgid "Rename ``JSONEncryption.flatten`` to ``.flattened``"
 msgstr ""
 
-#: ../../changelog.rst:170
+#: ../../changelog.rst:171
 msgid "Load and dump RSA, EC, and OKP key with password"
 msgstr ""
 
-#: ../../changelog.rst:171
+#: ../../changelog.rst:172
 msgid ""
 "Rename Curve key method: ``exchange_shared_key`` to "
 "``exchange_derive_key``"
 msgstr ""
 
-#: ../../changelog.rst:174
+#: ../../changelog.rst:175
 msgid "0.4.0"
 msgstr ""
 
-#: ../../changelog.rst:176
+#: ../../changelog.rst:177
 msgid "**Released on July 6, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:178
+#: ../../changelog.rst:179
 msgid "Change ``options`` to ``parameters`` for JWK methods"
 msgstr ""
 
-#: ../../changelog.rst:179
+#: ../../changelog.rst:180
 msgid "Change ``JWSRegistry`` and ``JWERegistry`` parameters"
 msgstr ""
 
-#: ../../changelog.rst:180
+#: ../../changelog.rst:181
 msgid "Guess ``sender_key`` from JWKs in JWE"
 msgstr ""
 
-#: ../../changelog.rst:181
+#: ../../changelog.rst:182
 msgid "Add importing key from DER encoding bytes"
 msgstr ""
 
-#: ../../changelog.rst:182
+#: ../../changelog.rst:183
 msgid "Fix JWS JSON serialization when members have only unprotected headers"
 msgstr ""
 
-#: ../../changelog.rst:183
+#: ../../changelog.rst:184
 msgid "Check key type before processing algorithms of JWS and JWE"
 msgstr ""
 
-#: ../../changelog.rst:186
+#: ../../changelog.rst:187
 msgid "0.3.0"
 msgstr ""
 
-#: ../../changelog.rst:188
+#: ../../changelog.rst:189
 msgid "**Released on June 29, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:190
+#: ../../changelog.rst:191
 msgid "Return ``str`` instead of ``bytes`` for JWS and JWE serializations"
 msgstr ""
 
-#: ../../changelog.rst:191
+#: ../../changelog.rst:192
 msgid "Add a ``detach_content`` method for JWS"
 msgstr ""
 
-#: ../../changelog.rst:192
+#: ../../changelog.rst:193
 msgid "Remove ``jwt.extract`` method, because ``extract`` won't work for JWE"
 msgstr ""
 
-#: ../../changelog.rst:193
+#: ../../changelog.rst:194
 msgid "Add ``JWKRegistry`` for JWK"
 msgstr ""
 
-#: ../../changelog.rst:194
+#: ../../changelog.rst:195
 msgid "Update ``JSONEncryption.add_recipient`` parameters"
 msgstr ""
 
-#: ../../changelog.rst:195
+#: ../../changelog.rst:196
 msgid "Export register methods for JWE drafts"
 msgstr ""
 
-#: ../../changelog.rst:198
+#: ../../changelog.rst:199
 msgid "0.2.0"
 msgstr ""
 
-#: ../../changelog.rst:200
+#: ../../changelog.rst:201
 msgid "**Released on June 25, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:202
+#: ../../changelog.rst:203
 msgid "A beta release."
 msgstr ""
 
-#: ../../changelog.rst:205
+#: ../../changelog.rst:206
 msgid "0.1.0"
 msgstr ""
 
-#: ../../changelog.rst:207
+#: ../../changelog.rst:208
 msgid "**Released on March 5, 2023**"
 msgstr ""
 
-#: ../../changelog.rst:209
+#: ../../changelog.rst:210
 msgid "Initial release."
 msgstr ""
+

--- a/docs/locales/zh/LC_MESSAGES/guide.po
+++ b/docs/locales/zh/LC_MESSAGES/guide.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  joserfc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-06-30 14:51+0900\n"
+"POT-Creation-Date: 2025-07-03 11:52+0900\n"
 "PO-Revision-Date: 2023-07-15 14:44+0900\n"
 "Last-Translator: Hsiaoming Yang <me@lepture.com>\n"
 "Language: zh\n"
@@ -448,6 +448,57 @@ msgid ""
 msgstr ""
 "``sender_key`` 可以是 :class:`~joserfc.jwk.KeySet`，JWE 会根据 ``skid`` "
 "头部值查找正确的密钥。"
+
+#: ../../guide/errors.rst:2
+msgid "Errors & Warnings"
+msgstr ""
+
+#: ../../guide/errors.rst:4
+msgid "Here are some common errors and warnings, and how to handle them."
+msgstr ""
+
+#: ../../guide/errors.rst:7
+msgid "SecurityWarning"
+msgstr ""
+
+#: ../../guide/errors.rst:9
+msgid ""
+"You may encounter a ``SecurityWarning`` when using potentially unsafe "
+"algorithms or generating insecure keys. These warnings do not interrupt "
+"the execution of your application — they are simply printed to standard "
+"output (e.g., your terminal)."
+msgstr ""
+
+#: ../../guide/errors.rst:14
+msgid ""
+"If you prefer to suppress these warnings, you can use Python’s built-in "
+"``warnings`` module:"
+msgstr ""
+
+#: ../../guide/errors.rst:24
+msgid ""
+"With this configuration, ``SecurityWarning`` messages will no longer "
+"appear. Be cautious when suppressing these warnings, as they are meant to"
+" alert you to potentially insecure practices."
+msgstr ""
+
+#: ../../guide/errors.rst:29 ../../guide/jws.rst:265
+msgid "UnsupportedAlgorithmError"
+msgstr ""
+
+#: ../../guide/errors.rst:31
+msgid ""
+"By default, **ONLY recommended** :ref:`jwa` are allowed. With non "
+"recommended algorithms, you may encounter the "
+"``UnsupportedAlgorithmError``` error."
+msgstr ""
+
+#: ../../guide/errors.rst:49
+msgid ""
+"Because \"HS384\" is not a recommended algorithm, it is not allowed by "
+"default. You SHOULD enable it manually by passing an ``algorithms`` "
+"parameter:"
+msgstr ""
 
 #: ../../guide/index.rst:4
 msgid "Guide"
@@ -1274,10 +1325,6 @@ msgstr ""
 msgid "ECDSA using secp256k1 curve and SHA-256"
 msgstr ""
 
-#: ../../guide/jws.rst:265
-msgid "UnsupportedAlgorithmError"
-msgstr ""
-
 #: ../../guide/jws.rst:269
 msgid ""
 "From version 1.1.0, an ``UnsupportedAlgorithmError`` will be raised "
@@ -1803,3 +1850,4 @@ msgid ""
 "Depending on the algorithm of the JWT, you need to decide whether to use "
 "``JWSRegistry`` or ``JWERegistry``."
 msgstr ""
+

--- a/src/joserfc/_rfc7518/oct_key.py
+++ b/src/joserfc/_rfc7518/oct_key.py
@@ -75,7 +75,7 @@ class OctKey(SymmetricKey):
             raise ValueError("Invalid bit size for oct key")
 
         if key_size < 112:
-            # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf
+            # https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final
             warnings.warn("Key size should be >= 112 bits", SecurityWarning)
 
         raw_key = secrets.token_bytes(key_size // 8)

--- a/src/joserfc/_rfc7518/rsa_key.py
+++ b/src/joserfc/_rfc7518/rsa_key.py
@@ -154,7 +154,7 @@ class RSAKey(AsymmetricKey[RSAPrivateKey, RSAPublicKey]):
             raise ValueError("Invalid key_size for RSAKey")
 
         if key_size < 2048:
-            # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf
+            # https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final
             warnings.warn("Key size should be >= 2048 bits", SecurityWarning)
 
         raw_key = generate_private_key(

--- a/src/joserfc/_rfc7518/rsa_key.py
+++ b/src/joserfc/_rfc7518/rsa_key.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import warnings
 from typing import TypedDict
 from functools import cached_property
 from cryptography.hazmat.primitives.asymmetric.rsa import (
@@ -14,6 +15,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import (
 )
 from cryptography.hazmat.backends import default_backend
 from ..registry import KeyParameter
+from ..errors import SecurityWarning
 from .._rfc7517.models import AsymmetricKey
 from .._rfc7517.pem import CryptographyBinding
 from .._rfc7517.types import KeyParameters
@@ -148,11 +150,12 @@ class RSAKey(AsymmetricKey[RSAPrivateKey, RSAPublicKey]):
         if key_size is None:
             key_size = 2048
 
-        if key_size < 512:
-            raise ValueError("key_size must not be less than 512")
-
         if key_size % 8 != 0:
             raise ValueError("Invalid key_size for RSAKey")
+
+        if key_size < 2048:
+            # https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf
+            warnings.warn("Key size should be >= 2048 bits", SecurityWarning)
 
         raw_key = generate_private_key(
             public_exponent=65537,


### PR DESCRIPTION
According to https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf

When generating keys, `OctKey` should be >= 112, and `RSAkey` should be >= 2048. 