### PR TITLE
fix: Correct function name for Chacha20-Poly1305 registration

### DIFF
--- a/docs/guide/algorithms.rst
+++ b/docs/guide/algorithms.rst
@@ -162,9 +162,9 @@ The default :ref:`registry` doesn't contain draft ciphers, developers MUST regis
 
 .. code-block:: python
 
-    from joserfc.drafts.jwe_chacha20 import register_chaha20_poly1305
+    from joserfc.drafts.jwe_chacha20 import register_chacha20_poly1305
 
-    register_chaha20_poly1305()
+    register_chacha20_poly1305()
 
 Use custom ``registry``
 +++++++++++++++++++++++

--- a/src/joserfc/drafts/jwe_chacha20.py
+++ b/src/joserfc/drafts/jwe_chacha20.py
@@ -3,7 +3,7 @@ from Crypto.Cipher import ChaCha20_Poly1305
 from .._rfc7516.registry import JWERegistry
 from .._rfc7516.models import JWEEncModel
 
-__all__ = ["ChaCha20EncModel", "JWE_ENC_MODELS", "register_chaha20_poly1305"]
+__all__ = ["ChaCha20EncModel", "JWE_ENC_MODELS", "register_chacha20_poly1305"]
 
 
 class ChaCha20EncModel(JWEEncModel):
@@ -36,6 +36,6 @@ XC20P = ChaCha20EncModel("XC20P", "XChaCha20-Poly1305", 192)
 JWE_ENC_MODELS = [C20P, XC20P]
 
 
-def register_chaha20_poly1305() -> None:
+def register_chacha20_poly1305() -> None:
     for model in JWE_ENC_MODELS:
         JWERegistry.register(model)

--- a/tests/jwe/test_chacha20.py
+++ b/tests/jwe/test_chacha20.py
@@ -5,9 +5,9 @@ from joserfc.jwe import (
     JWERegistry,
 )
 from joserfc.jwk import OctKey
-from joserfc.drafts.jwe_chacha20 import register_chaha20_poly1305
+from joserfc.drafts.jwe_chacha20 import register_chacha20_poly1305
 
-register_chaha20_poly1305()
+register_chacha20_poly1305()
 chacha_registry = JWERegistry(algorithms=["dir", "C20P", "XC20P"])
 
 


### PR DESCRIPTION
This PR fixes a typo in the function name for registering the Chacha20-Poly1305 algorithm. The issue was found during testing of the draft implementation.

```python
def register_chaha20_poly1305():
```

```python
def register_chacha20_poly1305():
```

referenced issue: https://github.com/authlib/joserfc/issues/66