### PR TITLE
check_key checks the curve compatibility with EdDSA

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Changelog
 **Unreleased**
 
 - ``filter_algorithms`` ``names`` defaults to all algs. :pr:`79`
+- check_key checks the curve compatibility with EdDSA. :pr:`80`
 
 1.5.0
 -----

--- a/src/joserfc/_rfc9864/jws_eddsa.py
+++ b/src/joserfc/_rfc9864/jws_eddsa.py
@@ -18,6 +18,12 @@ class EdDSAAlgorithm(JWSAlgModel):
         self.name = curve
         self.description = f"EdDSA using the {curve} parameter set"
 
+    def check_key(self, key: OKPKey) -> None:
+        super().check_key(key)
+        public_key_cls = _public_key_mapping[self.name]
+        if not isinstance(key.public_key, public_key_cls):
+            raise InvalidKeyTypeError(f"Algorithm '{self.name}' requires '{self.name}' OKP key")
+
     def sign(self, msg: bytes, key: OKPKey) -> bytes:
         op_key = t.cast(t.Union[Ed25519PrivateKey, Ed448PrivateKey], key.get_op_key("sign"))
         private_key_cls = _private_key_mapping[self.name]

--- a/tests/jws/test_eddsa.py
+++ b/tests/jws/test_eddsa.py
@@ -2,6 +2,7 @@ import typing as t
 from unittest import TestCase
 from joserfc import jwt
 from joserfc.jwk import OKPKey
+from joserfc._rfc9864 import Ed25519, Ed448
 from joserfc.errors import InvalidKeyTypeError, BadSignatureError
 from tests.base import load_key
 
@@ -39,3 +40,21 @@ class TestEdDSA(TestCase):
         self.assertRaises(InvalidKeyTypeError, jwt.decode, encoded_jwt, self.ed25519_key, algorithms=algorithms)
         wrong_key = OKPKey.generate_key("Ed448", private=False)
         self.assertRaises(BadSignatureError, jwt.decode, encoded_jwt, wrong_key, algorithms=algorithms)
+
+    def test_Ed25519_sign_with_wrong_key(self):
+        """Ed25519.sign should reject Ed448 keys."""
+        self.assertRaises(InvalidKeyTypeError, Ed25519.sign, b"test", self.ed448_key)
+
+    def test_Ed25519_verify_with_wrong_key(self):
+        """Ed25519.verify should reject Ed448 keys."""
+        sig = Ed25519.sign(b"test", self.ed25519_key)
+        self.assertRaises(InvalidKeyTypeError, Ed25519.verify, b"test", sig, self.ed448_key)
+
+    def test_Ed448_sign_with_wrong_key(self):
+        """Ed448.sign should reject Ed25519 keys."""
+        self.assertRaises(InvalidKeyTypeError, Ed448.sign, b"test", self.ed25519_key)
+
+    def test_Ed448_verify_with_wrong_key(self):
+        """Ed448.verify should reject Ed25519 keys."""
+        sig = Ed448.sign(b"test", self.ed448_key)
+        self.assertRaises(InvalidKeyTypeError, Ed448.verify, b"test", sig, self.ed25519_key)

--- a/tests/jws/test_registry.py
+++ b/tests/jws/test_registry.py
@@ -45,3 +45,21 @@ class JWSRegistryTest(unittest.TestCase):
         explicit = JWSRegistry.filter_algorithms(self.rsa_key, all_names)
         default = JWSRegistry.filter_algorithms(self.rsa_key)
         self.assertEqual(explicit, default)
+
+    def test_filter_algorithms_ed25519(self):
+        """Ed25519 keys should only be compatible with EdDSA and Ed25519, not Ed448."""
+        ed25519_key = OKPKey.generate_key("Ed25519")
+        algs = JWSRegistry.filter_algorithms(ed25519_key, JWSRegistry.algorithms.keys())
+        names = [alg.name for alg in algs]
+        self.assertIn("EdDSA", names)
+        self.assertIn("Ed25519", names)
+        self.assertNotIn("Ed448", names)
+
+    def test_filter_algorithms_ed448(self):
+        """Ed448 keys should only be compatible with EdDSA and Ed448, not Ed25519."""
+        ed448_key = OKPKey.generate_key("Ed448")
+        algs = JWSRegistry.filter_algorithms(ed448_key, JWSRegistry.algorithms.keys())
+        names = [alg.name for alg in algs]
+        self.assertIn("EdDSA", names)
+        self.assertIn("Ed448", names)
+        self.assertNotIn("Ed25519", names)


### PR DESCRIPTION
This aligns the `check_key` behavior with `sign` and `verify`.
This is helpful since it is called by `filter_algorithms`. This way `filter_algorithms` don't return invalid args.