### PR TITLE
docs: python-jose jwt claims validation

### DIFF
--- a/docs/migrations/python-jose.rst
+++ b/docs/migrations/python-jose.rst
@@ -111,6 +111,12 @@ differ significantly in terms of structure and flexibility.
     # => token.header : {"alg": "HS256"}
     # => token.claims : {"a": "b"}
 
+.. warning::
+
+    ``python-jose`` will automatically convert and validate string values for JWT claims
+    (e.g. `exp`, `iat` and `nbf`) whereas ``joserfc`` will raise an exception when
+    using the `JWTClaimsRegistry`.
+
 ``get_unverified_header``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hit by this surprise when migrating from `python-jose` to `joserfc`.

`python-jose` will convert certain claims to `int` for validation whereas `joserfc` is more strict and requires `int`.

https://github.com/mpdavis/python-jose/blob/018b310ddb8b50dcfd09a0c152117835a21dd656/jose/jwt.py#L323-L326

```py
from jose import jwt
encoded = jwt.encode({'exp': '1799927093'}, 'your-secret-key', algorithm='HS256')
jwt.decode(encoded, 'your-secret-key', algorithms='HS256')
> {'exp': '1799927093'}
```

Adding warning to docs as it might save others.