### PR TITLE
Increase max payload length to 128000 bytes

### DIFF
--- a/src/joserfc/_rfc7515/registry.py
+++ b/src/joserfc/_rfc7515/registry.py
@@ -49,7 +49,7 @@ class JWSRegistry:
     #: max header content's size in bytes
     max_header_length: int = 512
     #: max payload content's size in bytes
-    max_payload_length: int = 8000
+    max_payload_length: int = 128000
     #: max signature's size in bytes
     max_signature_length: int = 1024
 

--- a/tests/jws/test_compact.py
+++ b/tests/jws/test_compact.py
@@ -61,7 +61,7 @@ class TestCompact(TestCase):
 
     def test_payload_exceeded_size_error(self):
         header = json_b64encode({"alg": "HS256"})
-        exceeded_payload = urlsafe_b64encode(("o" * 10000).encode("utf8"))
+        exceeded_payload = urlsafe_b64encode(("o" * (128000 + 1)).encode("utf8"))
         fake_jws = header + b"." + exceeded_payload + b"." + urlsafe_b64encode(b"o")
         self.assertRaises(ExceededSizeError, deserialize_compact, fake_jws, self.key)
 


### PR DESCRIPTION
solve https://github.com/authlib/joserfc/issues/92

some organizations have large jwt claims that have been in the 32k range.

I feel 128k is safe and unlikely to be hit unless something is very wrong on the auth provider end.