### PR TITLE
fix(jws): validate payload size for b64=false

### DIFF
--- a/src/joserfc/_rfc7797/compact.py
+++ b/src/joserfc/_rfc7797/compact.py
@@ -49,6 +49,8 @@ def extract_rfc7515_compact(
 
     registry.validate_header_size(header_segment)
     registry.validate_signature_size(signature_segment)
+    if payload_segment:
+        registry.validate_payload_size(payload_segment)
 
     protected = decode_header(header_segment)
 
@@ -61,7 +63,6 @@ def extract_rfc7515_compact(
             payload = to_bytes(payload)
             payload_segment = urlsafe_b64encode(payload)
         else:
-            registry.validate_payload_size(payload_segment)
             try:
                 payload = urlsafe_b64decode(payload_segment)
             except (TypeError, ValueError):

--- a/src/joserfc/_rfc7797/json.py
+++ b/src/joserfc/_rfc7797/json.py
@@ -31,10 +31,11 @@ def extract_rfc7797_json(value: FlattenedJSONSerialization, registry: JWSRegistr
     member = HeaderMember(protected, header)
 
     payload_segment: bytes = value["payload"].encode("utf-8")
+    registry.validate_payload_size(payload_segment)
+
     if is_rfc7797_enabled(member.headers()):
         payload = payload_segment
     else:
-        registry.validate_payload_size(payload_segment)
         try:
             payload = urlsafe_b64decode(payload_segment)
         except (TypeError, ValueError):


### PR DESCRIPTION
Always run `validate_payload_size`.