### PR TITLE
fix(rfc7797): enforce payload size limit for b64=false JWS (GHSA-wphv-vfrh-23q5)

### DIFF
--- a/src/joserfc/_rfc7797/compact.py
+++ b/src/joserfc/_rfc7797/compact.py
@@ -57,6 +57,7 @@ def extract_rfc7515_compact(
         if not payload_segment and payload:
             payload_segment = to_bytes(payload)
         payload = payload_segment
+        registry.validate_payload_size(payload)
     else:
         if not payload_segment and payload:
             payload = to_bytes(payload)

--- a/src/joserfc/_rfc7797/json.py
+++ b/src/joserfc/_rfc7797/json.py
@@ -34,6 +34,7 @@ def extract_rfc7797_json(value: FlattenedJSONSerialization, registry: JWSRegistr
 
     if is_rfc7797_enabled(member.headers()):
         payload = payload_segment
+        registry.validate_payload_size(payload)
     else:
         try:
             payload = urlsafe_b64decode(payload_segment)

--- a/tests/jws/test_rfc7797.py
+++ b/tests/jws/test_rfc7797.py
@@ -6,6 +6,7 @@ from joserfc.errors import (
     InvalidHeaderValueError,
     MissingCritHeaderError,
     UnsupportedHeaderError,
+    ExceededSizeError,
 )
 from joserfc.util import to_bytes
 from joserfc.jws import HeaderDict
@@ -84,6 +85,23 @@ class TestRFC7797(TestFixture):
         value = jws.serialize_json(member, "hello", default_key)
         key2 = OctKey.import_key("secret")
         self.assertRaises(BadSignatureError, jws.deserialize_json, value, key2)
+
+    def test_rfc7797_payload_size_limit_compact(self):
+        """RFC7797 b64=false compact: oversized payload should be rejected.
+        Regression test for GHSA-wphv-vfrh-23q5."""
+        protected = {"alg": "HS256", "b64": False, "crit": ["b64"]}
+        big_payload = "x" * 200_000  # exceeds default max_payload_length (128000)
+        value = jws.serialize_compact(protected, big_payload, default_key)
+        # deserialize without payload= arg (no detached content) should reject
+        self.assertRaises(ExceededSizeError, jws.deserialize_compact, value, default_key)
+
+    def test_rfc7797_payload_size_limit_json(self):
+        """RFC7797 b64=false flattened JSON: oversized payload should be rejected.
+        Regression test for GHSA-wphv-vfrh-23q5."""
+        member: HeaderDict = {"protected": {"alg": "HS256", "b64": False, "crit": ["b64"]}}
+        big_payload = "x" * 200_000
+        value = jws.serialize_json(member, big_payload, default_key)
+        self.assertRaises(ExceededSizeError, jws.deserialize_json, value, default_key)
 
 
 TestRFC7797.load_fixture("jws_rfc7797.json")


### PR DESCRIPTION
## Vulnerability

**Type:** Missing Size Validation (CWE-1307)
**Advisory:** GHSA-wphv-vfrh-23q5
**CVSS:** CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L => 5.3 Medium
**Affected versions:** >= 1.3.4, < 1.6.7

The RFC7797 (b64=false) compact and flattened JSON deserialization paths in `_rfc7797/compact.py` and `_rfc7797/json.py` accepted oversized payloads without applying `JWSRegistry.max_payload_length`. The normal compact path calls `validate_payload_size()` before decoding, but the RFC7797 unencoded-payload branches assigned the raw payload bytes directly without ever validating the size.

## Reproduction

```bash
pip install "joserfc==1.6.5"
```

```python
from joserfc.jwk import OctKey
from joserfc import jws

key = OctKey.import_key({"kty": "oct", "k": "AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"})

# Normal JWS: rejected (correct)
normal_header = {"alg": "HS256"}
big = "x" * 200_000
normal_jws = jws.serialize_compact(normal_header, big, key)
# → ExceededSizeError ✓

# RFC7797 b64=false: ACCEPTED (bypass)
rfc7797_header = {"alg": "HS256", "b64": False, "crit": ["b64"]}
bypass_jws = jws.serialize_compact(rfc7797_header, big, key)
obj = jws.deserialize_compact(bypass_jws, key)
# → NO error (payload accepted despite exceeding 128000 byte limit)
```

## Fix

Two minimal changes (2 lines):

1. **`src/joserfc/_rfc7797/compact.py:59`**: Added `registry.validate_payload_size(payload)` after `payload = payload_segment` in the RFC7797 compact extraction branch.

2. **`src/joserfc/_rfc7797/json.py:36`**: Added `registry.validate_payload_size(payload)` after `payload = payload_segment` in the RFC7797 flattened JSON extraction branch.

## Regression test

Two new tests in `tests/jws/test_rfc7797.py`:

```bash
python -m pytest tests/jws/test_rfc7797.py -v
# test_rfc7797_payload_size_limit_compact PASSED
# test_rfc7797_payload_size_limit_json PASSED
```

Full test suite: 278 passed, 0 skipped (unrelated chacha20 test skipped due to missing pycryptodome).