### PR TITLE
Ignore unknown kty in KeySet.import_key_set (RFC 7517 §5)

### DIFF
--- a/src/joserfc/_keys.py
+++ b/src/joserfc/_keys.py
@@ -167,6 +167,13 @@ class KeySet:
         keys: list[Key] = []
 
         for data in value["keys"]:
+            # RFC 7517, Section 5: ignore a key whose "kty" is not understood
+            # rather than failing the whole set (for example a post-quantum key
+            # published alongside classical ones).
+            if isinstance(data, dict):
+                kty = data.get("kty")
+                if kty is not None and kty not in cls.registry_cls.key_types:
+                    continue
             keys.append(cls.registry_cls.import_key(data, parameters=parameters))
 
         if not keys:

--- a/src/joserfc/_keys.py
+++ b/src/joserfc/_keys.py
@@ -170,11 +170,10 @@ class KeySet:
             # RFC 7517, Section 5: ignore a key whose "kty" is not understood
             # rather than failing the whole set (for example a post-quantum key
             # published alongside classical ones).
-            if isinstance(data, dict):
-                kty = data.get("kty")
-                if kty is not None and kty not in cls.registry_cls.key_types:
-                    continue
-            keys.append(cls.registry_cls.import_key(data, parameters=parameters))
+            try:
+                keys.append(cls.registry_cls.import_key(data, parameters=parameters))
+            except InvalidKeyTypeError:
+                continue
 
         if not keys:
             raise MissingKeyError("No keys to import")

--- a/tests/jwk/test_jwk_set.py
+++ b/tests/jwk/test_jwk_set.py
@@ -11,6 +11,16 @@ class TestKeySet(TestCase):
     def test_import_empty_key_set(self):
         self.assertRaises(MissingKeyError, KeySet.import_key_set, {"keys": []})
 
+    def test_import_key_set_ignores_unknown_kty(self):
+        # RFC 7517 Section 5: a key with an unrecognised "kty" is ignored, not fatal.
+        jwks = {"keys": [
+            {"kty": "unknown", "alg": "X", "kid": "unknown"},
+            {"kty": "oct", "k": "MDEyMzQ1Njc4OWFiY2RlZg", "kid": "classical"},
+        ]}
+        key_set = KeySet.import_key_set(jwks)
+        self.assertEqual(len(key_set.keys), 1)
+        self.assertEqual(key_set.keys[0].kid, "classical")
+
     def test_generate_and_import_key_set(self):
         jwks1 = KeySet.generate_key_set("RSA", 2048)
         self.assertEqual(len(jwks1.keys), 4)


### PR DESCRIPTION
### What

`KeySet.import_key_set` now skips a key whose `kty` is present but not in the registry, instead of raising `InvalidKeyTypeError` and failing the whole set.

### Why

Today `import_key_set` imports each key eagerly, so the first key with an unrecognised `kty` raises (`Invalid key type: '...'`) and the entire set fails. RFC 7517 §5 says a processor SHOULD ignore key types it does not understand.

This is becoming a live issue as post-quantum keys (ML-DSA, `kty:"AKP"`, RFC 9964) begin appearing in published JWKS next to RSA/EC keys: one unknown key otherwise stops the classical keys next to it from verifying. (Companion to the same fix in authlib, authlib/authlib#914, since `authlib.jose` points here as its successor.)

### Change

- `import_key_set` skips only keys whose `kty` is explicitly present and not in `registry_cls.key_types`; a recognised-but-malformed key still raises, and a set with no usable keys still raises `MissingKeyError` as before.
- Added `test_import_key_set_ignores_unknown_kty`.

`tests/jwk/test_jwk_set.py` passes (11 passed).